### PR TITLE
SL1 source codes in YAML

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pylint
         pip install coverage
+        pip install pyyaml
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with pylint
       run: |

--- a/10_SL1/errors.yaml
+++ b/10_SL1/errors.yaml
@@ -1,0 +1,342 @@
+Errors:
+- code: "10101"
+  title: "TILT HOME FAILED"
+  text: null
+  id: "TILT_HOME_FAILED"
+  approved: false
+- code: "10102"
+  title: "TOWER HOME FAILED"
+  text: null
+  id: "TOWER_HOME_FAILED"
+  approved: false
+- code: "10103"
+  title: "TOWER MOVE FAILED"
+  text: null
+  id: "TOWER_MOVE_FAILED"
+  approved: false
+- code: "10106"
+  title: "FAN FAILED"
+  text: null
+  id: "FAN_FAILED"
+  approved: false
+- code: "10108"
+  title: "RESIN TOO LOW"
+  text: null
+  id: "RESIN_TOO_LOW"
+  approved: false
+- code: "10109"
+  title: "RESIN TOO HIGH"
+  text: null
+  id: "RESIN_TOO_HIGH"
+  approved: false
+- code: "10113"
+  title: "NOT MECHANICALLY CALIBRATED"
+  text: null
+  id: "NOT_MECHANICALLY_CALIBRATED"
+  approved: false
+- code: "10114"
+  title: "TOWER ENDSTOP NOT REACHED"
+  text: "Failed to reach tower endstop"
+  id: "TOWER_ENDSTOP_NOT_REACHED"
+  approved: false
+- code: "10115"
+  title: "TILT ENDSTOP NOT REACHED"
+  text: "Failed to reach tilt endstop"
+  id: "TILT_ENDSTOP_NOT_REACHED"
+  approved: false
+- code: "10118"
+  title: "TOWER AXIS CHECK FAILED"
+  text: "Tower axis check failed!
+
+
+    Current position: %d nm
+
+
+    Please check if the ballscrew can move smoothly in its entire range."
+  id: "TOWER_AXIS_CHECK_FAILED"
+  approved: false
+- code: "10119"
+  title: "TILT AXIS CHECK FAILED"
+  text: "Tilt axis check failed!
+
+
+    Current position: %d steps
+
+
+    Please check if the tilt can move smoothly in its entire range."
+  id: "TILT_AXIS_CHECK_FAILED"
+  approved: false
+- code: "10120"
+  title: "DISPLAY TEST FAILED"
+  text: "Display test failed."
+  id: "DISPLAY_TEST_FAILED"
+  approved: false
+- code: "10121"
+  title: "INVALID TILT ALIGN POSITION"
+  text: "Invalid tilt align position"
+  id: "INVALID_TILT_ALIGN_POSITION"
+  approved: false
+- code: "10122"
+  title: "FAN RPM OUT OF TEST RANGE"
+  text: "RPM of %(fan)s not in range!
+
+
+    Please check if the fan is connected correctly.
+
+
+    RPM data: %(rpm)s
+
+    Average: %(avg)s
+
+    Fan error: %(fanError)s"
+  id: "FAN_RPM_OUT_OF_TEST_RANGE"
+  approved: false
+- code: "10123"
+  title: "TOWER BELOW SURFACE"
+  text: "Tower not at the expected position.
+
+
+    Is the platform and tank secured in correct position?
+
+
+    "
+  id: "TOWER_BELOW_SURFACE"
+  approved: false
+- code: "10205"
+  title: "TEMP SENSOR FAILED"
+  text: null
+  id: "TEMP_SENSOR_FAILED"
+  approved: false
+- code: "10206"
+  title: "UVLED HEAT SINK FAILED"
+  text: "UV LED overheating! Check proper heatsink installation."
+  id: "UVLED_HEAT_SINK_FAILED"
+  approved: false
+- code: "10401"
+  title: "MQTT SEND FAILED"
+  text: "Cannot send factory config to MQTT!"
+  id: "MQTT_SEND_FAILED"
+  approved: false
+- code: "10402"
+  title: "NOT CONNECTED TO NETWORK"
+  text: null
+  id: "NOT_CONNECTED_TO_NETWORK"
+  approved: false
+- code: "10403"
+  title: "CONNECTION FAILED"
+  text: null
+  id: "CONNECTION_FAILED"
+  approved: false
+- code: "10404"
+  title: "DOWNLOAD FAILED"
+  text: null
+  id: "DOWNLOAD_FAILED"
+  approved: false
+- code: "10301"
+  title: "MOTION CONTROLLER WRONG REVISION"
+  text: "Wrong revision of the motion controller. Please replace it or contact our support."
+  id: "MOTION_CONTROLLER_WRONG_REVISION"
+  approved: false
+- code: "10306"
+  title: "MOTION CONTROLLER EXCEPTION"
+  text: null
+  id: "MOTION_CONTROLLER_EXCEPTION"
+  approved: false
+- code: "10307"
+  title: "RESIN SENSOR FAILED"
+  text: null
+  id: "RESIN_SENSOR_FAILED"
+  approved: false
+- code: "10308"
+  title: "NOT UV CALIBRATED"
+  text: null
+  id: "NOT_UV_CALIBRATED"
+  approved: false
+- code: "10309"
+  title: "UVLED VOLTAGE DIFFER TOO MUCH"
+  text: "UV LED voltages differ too much. Possibly LED module is broken."
+  id: "UVLED_VOLTAGE_DIFFER_TOO_MUCH"
+  approved: false
+- code: "10310"
+  title: "SOUND TEST FAILED"
+  text: "Speaker is broken"
+  id: "SOUND_TEST_FAILED"
+  approved: false
+- code: "10500"
+  title: "NONE"
+  text: "No problem"
+  id: "NONE"
+  approved: false
+- code: "10501"
+  title: "UNKNOWN"
+  text: "An unexpected error has occurred :-(.
+
+
+    If the SL1 is printing, current job will be finished.
+
+
+    You can turn the printer off by pressing the front power button.
+
+
+    Please follow the instructions in Chapter 3.1 in the handbook to learn how to
+    save a log file. Please send the log to us and help us improve the printer.
+
+
+    Thank you!"
+  id: "UNKNOWN"
+  approved: false
+- code: "10503"
+  title: "PRELOAD FAILED"
+  text: "Image preloader did not finish successfully!"
+  id: "PRELOAD_FAILED"
+  approved: false
+- code: "10504"
+  title: "PROJECT FAILED"
+  text: null
+  id: "PROJECT_FAILED"
+  approved: false
+- code: "10505"
+  title: "CONFIG EXCEPTION"
+  text: "Failed to read configuration file"
+  id: "CONFIG_EXCEPTION"
+  approved: false
+- code: "10506"
+  title: "NOT AVAILABLE IN STATE"
+  text: null
+  id: "NOT_AVAILABLE_IN_STATE"
+  approved: false
+- code: "10507"
+  title: "DBUS MAPPING ERROR"
+  text: null
+  id: "DBUS_MAPPING_ERROR"
+  approved: false
+- code: "10508"
+  title: "REPRINT WITHOUT HISTORY"
+  text: null
+  id: "REPRINT_WITHOUT_HISTORY"
+  approved: false
+- code: "10509"
+  title: "MISSING WIZARD DATA"
+  text: "The wizard did not finish successfully!"
+  id: "MISSING_WIZARD_DATA"
+  approved: false
+- code: "10510"
+  title: "MISSING CALIBRATION DATA"
+  text: "The calibration did not finish successfully!"
+  id: "MISSING_CALIBRATION_DATA"
+  approved: false
+- code: "10511"
+  title: "MISSING UVCALIBRATION DATA"
+  text: "The automatic UV LED calibration did not finish successfully!"
+  id: "MISSING_UVCALIBRATION_DATA"
+  approved: false
+- code: "10512"
+  title: "MISSING UVPWM SETTINGS"
+  text: null
+  id: "MISSING_UVPWM_SETTINGS"
+  approved: false
+- code: "10513"
+  title: "FAILED UPDATE CHANNEL SET"
+  text: "Cannot set update channel"
+  id: "FAILED_UPDATE_CHANNEL_SET"
+  approved: false
+- code: "10514"
+  title: "FAILED UPDATE CHANNEL GET"
+  text: null
+  id: "FAILED_UPDATE_CHANNEL_GET"
+  approved: false
+- code: "10515"
+  title: "WARNING ESCALATION"
+  text: null
+  id: "WARNING_ESCALATION"
+  approved: false
+- code: "10516"
+  title: "NOT ENOUGH INTERNAL SPACE"
+  text: null
+  id: "NOT_ENOUGH_INTERNAL_SPACE"
+  approved: false
+- code: "10517"
+  title: "ADMIN NOT AVAILABLE"
+  text: null
+  id: "ADMIN_NOT_AVAILABLE"
+  approved: false
+- code: "10518"
+  title: "FILE NOT FOUND"
+  text: "Cannot find a file!"
+  id: "FILE_NOT_FOUND"
+  approved: false
+- code: "10519"
+  title: "INVALID EXTENSION"
+  text: "File has an invalid extension!"
+  id: "INVALID_EXTENSION"
+  approved: false
+- code: "10520"
+  title: "FILE ALREADY EXISTS"
+  text: "File already exists!"
+  id: "FILE_ALREADY_EXISTS"
+  approved: false
+- code: "10521"
+  title: "INVALID PROJECT"
+  text: "The project file is invalid!"
+  id: "INVALID_PROJECT"
+  approved: false
+- code: "10522"
+  title: "WIZARD NOT CANCELABLE"
+  text: "This wizard cannot be canceled"
+  id: "WIZARD_NOT_CANCELABLE"
+  approved: false
+- code: "10700"
+  title: "NONE WARNING"
+  text: "No warning"
+  id: "NONE_WARNING"
+  approved: false
+- code: "10701"
+  title: "UNKNOWN WARNING"
+  text: "Unknown warning"
+  id: "UNKNOWN_WARNING"
+  approved: false
+- code: "10702"
+  title: "AMBIENT TOO HOT WARNING"
+  text: null
+  id: "AMBIENT_TOO_HOT_WARNING"
+  approved: false
+- code: "10703"
+  title: "AMBIENT TOO COLD WARNING"
+  text: null
+  id: "AMBIENT_TOO_COLD_WARNING"
+  approved: false
+- code: "10704"
+  title: "PRINTING DIRECTLY WARNING"
+  text: null
+  id: "PRINTING_DIRECTLY_WARNING"
+  approved: false
+- code: "10705"
+  title: "PRINTER MODEL MISMATCH WARNING"
+  text: null
+  id: "PRINTER_MODEL_MISMATCH_WARNING"
+  approved: false
+- code: "10706"
+  title: "RESIN NOT ENOUGH WARNING"
+  text: null
+  id: "RESIN_NOT_ENOUGH_WARNING"
+  approved: false
+- code: "10707"
+  title: "PROJECT SETTINGS MODIFIED WARNING"
+  text: null
+  id: "PROJECT_SETTINGS_MODIFIED_WARNING"
+  approved: false
+- code: "10708"
+  title: "PERPARTES NOAVAIL WARNING"
+  text: null
+  id: "PERPARTES_NOAVAIL_WARNING"
+  approved: false
+- code: "10709"
+  title: "MASK NOAVAIL WARNING"
+  text: null
+  id: "MASK_NOAVAIL_WARNING"
+  approved: false
+- code: "10710"
+  title: "OBJECT TRUNCATED WARNING"
+  text: null
+  id: "OBJECT_TRUNCATED_WARNING"
+  approved: false

--- a/10_SL1/errors.yaml
+++ b/10_SL1/errors.yaml
@@ -1,49 +1,76 @@
+# Error codes list for Original Prusa SL1 printer
+# GitHub repo https://github.com/prusa3d/Prusa-Error-Codes
+
+# Printer code
+# SL1            10xxx
+
+# Error categories
+# MECHANICAL     xx1xx   # Mechanical failures, engines XYZ, tower
+# TEMPERATURE    xx2xx   # Temperature measurement, thermistors, heating
+# ELECTRICAL     xx3xx   # Electrical, MINDA, FINDA, Motion Controller, …
+# CONNECTIVITY   xx4xx   # Connectivity - Wi - Fi, LAN, Prusa Connect Cloud
+# SYSTEM         xx5xx   # System - BSOD, ...
+# BOOTLOADER     xx6xx   #
+# WARNINGS       xx7xx   # Category-less warnings
+
+
+
 Errors:
+# MECHANICAL     101xx   # Mechanical failures, engines XYZ, tower
 - code: "10101"
   title: "TILT HOME FAILED"
   text: null
   id: "TILT_HOME_FAILED"
   approved: false
+
 - code: "10102"
   title: "TOWER HOME FAILED"
   text: null
   id: "TOWER_HOME_FAILED"
   approved: false
+
 - code: "10103"
   title: "TOWER MOVE FAILED"
   text: null
   id: "TOWER_MOVE_FAILED"
   approved: false
+
 - code: "10106"
   title: "FAN FAILED"
   text: null
   id: "FAN_FAILED"
   approved: false
+
 - code: "10108"
   title: "RESIN TOO LOW"
   text: null
   id: "RESIN_TOO_LOW"
   approved: false
+
 - code: "10109"
   title: "RESIN TOO HIGH"
   text: null
   id: "RESIN_TOO_HIGH"
   approved: false
+
 - code: "10113"
   title: "NOT MECHANICALLY CALIBRATED"
   text: null
   id: "NOT_MECHANICALLY_CALIBRATED"
   approved: false
+
 - code: "10114"
   title: "TOWER ENDSTOP NOT REACHED"
   text: "Failed to reach tower endstop"
   id: "TOWER_ENDSTOP_NOT_REACHED"
   approved: false
+
 - code: "10115"
   title: "TILT ENDSTOP NOT REACHED"
   text: "Failed to reach tilt endstop"
   id: "TILT_ENDSTOP_NOT_REACHED"
   approved: false
+
 - code: "10118"
   title: "TOWER AXIS CHECK FAILED"
   text: "Tower axis check failed!
@@ -55,6 +82,7 @@ Errors:
     Please check if the ballscrew can move smoothly in its entire range."
   id: "TOWER_AXIS_CHECK_FAILED"
   approved: false
+
 - code: "10119"
   title: "TILT AXIS CHECK FAILED"
   text: "Tilt axis check failed!
@@ -66,16 +94,19 @@ Errors:
     Please check if the tilt can move smoothly in its entire range."
   id: "TILT_AXIS_CHECK_FAILED"
   approved: false
+
 - code: "10120"
   title: "DISPLAY TEST FAILED"
   text: "Display test failed."
   id: "DISPLAY_TEST_FAILED"
   approved: false
+
 - code: "10121"
   title: "INVALID TILT ALIGN POSITION"
   text: "Invalid tilt align position"
   id: "INVALID_TILT_ALIGN_POSITION"
   approved: false
+
 - code: "10122"
   title: "FAN RPM OUT OF TEST RANGE"
   text: "RPM of %(fan)s not in range!
@@ -91,6 +122,7 @@ Errors:
     Fan error: %(fanError)s"
   id: "FAN_RPM_OUT_OF_TEST_RANGE"
   approved: false
+
 - code: "10123"
   title: "TOWER BELOW SURFACE"
   text: "Tower not at the expected position.
@@ -102,71 +134,101 @@ Errors:
     "
   id: "TOWER_BELOW_SURFACE"
   approved: false
+
+
+
+
+# TEMPERATURE    102xx   # Temperature measurement, thermistors, heating
 - code: "10205"
   title: "TEMP SENSOR FAILED"
   text: null
   id: "TEMP_SENSOR_FAILED"
   approved: false
+
 - code: "10206"
   title: "UVLED HEAT SINK FAILED"
   text: "UV LED overheating! Check proper heatsink installation."
   id: "UVLED_HEAT_SINK_FAILED"
   approved: false
-- code: "10401"
-  title: "MQTT SEND FAILED"
-  text: "Cannot send factory config to MQTT!"
-  id: "MQTT_SEND_FAILED"
-  approved: false
-- code: "10402"
-  title: "NOT CONNECTED TO NETWORK"
-  text: null
-  id: "NOT_CONNECTED_TO_NETWORK"
-  approved: false
-- code: "10403"
-  title: "CONNECTION FAILED"
-  text: null
-  id: "CONNECTION_FAILED"
-  approved: false
-- code: "10404"
-  title: "DOWNLOAD FAILED"
-  text: null
-  id: "DOWNLOAD_FAILED"
-  approved: false
+
+
+
+
+# ELECTRICAL     103xx   # Electrical, MINDA, FINDA, Motion Controller, …
 - code: "10301"
   title: "MOTION CONTROLLER WRONG REVISION"
   text: "Wrong revision of the motion controller. Please replace it or contact our support."
   id: "MOTION_CONTROLLER_WRONG_REVISION"
   approved: false
+
 - code: "10306"
   title: "MOTION CONTROLLER EXCEPTION"
   text: null
   id: "MOTION_CONTROLLER_EXCEPTION"
   approved: false
+
 - code: "10307"
   title: "RESIN SENSOR FAILED"
   text: null
   id: "RESIN_SENSOR_FAILED"
   approved: false
+
 - code: "10308"
   title: "NOT UV CALIBRATED"
   text: null
   id: "NOT_UV_CALIBRATED"
   approved: false
+
 - code: "10309"
   title: "UVLED VOLTAGE DIFFER TOO MUCH"
   text: "UV LED voltages differ too much. Possibly LED module is broken."
   id: "UVLED_VOLTAGE_DIFFER_TOO_MUCH"
   approved: false
+
 - code: "10310"
   title: "SOUND TEST FAILED"
   text: "Speaker is broken"
   id: "SOUND_TEST_FAILED"
   approved: false
+
+
+
+
+# CONNECTIVITY   104xx   # Connectivity - Wi - Fi, LAN, Prusa Connect Cloud
+- code: "10401"
+  title: "MQTT SEND FAILED"
+  text: "Cannot send factory config to MQTT!"
+  id: "MQTT_SEND_FAILED"
+  approved: false
+
+- code: "10402"
+  title: "NOT CONNECTED TO NETWORK"
+  text: null
+  id: "NOT_CONNECTED_TO_NETWORK"
+  approved: false
+
+- code: "10403"
+  title: "CONNECTION FAILED"
+  text: null
+  id: "CONNECTION_FAILED"
+  approved: false
+
+- code: "10404"
+  title: "DOWNLOAD FAILED"
+  text: null
+  id: "DOWNLOAD_FAILED"
+  approved: false
+
+
+
+
+# SYSTEM         105xx   # System - BSOD, ...
 - code: "10500"
   title: "NONE"
   text: "No problem"
   id: "NONE"
   approved: false
+
 - code: "10501"
   title: "UNKNOWN"
   text: "An unexpected error has occurred :-(.
@@ -185,156 +247,191 @@ Errors:
     Thank you!"
   id: "UNKNOWN"
   approved: false
+
 - code: "10503"
   title: "PRELOAD FAILED"
   text: "Image preloader did not finish successfully!"
   id: "PRELOAD_FAILED"
   approved: false
+
 - code: "10504"
   title: "PROJECT FAILED"
   text: null
   id: "PROJECT_FAILED"
   approved: false
+
 - code: "10505"
   title: "CONFIG EXCEPTION"
   text: "Failed to read configuration file"
   id: "CONFIG_EXCEPTION"
   approved: false
+
 - code: "10506"
   title: "NOT AVAILABLE IN STATE"
   text: null
   id: "NOT_AVAILABLE_IN_STATE"
   approved: false
+
 - code: "10507"
   title: "DBUS MAPPING ERROR"
   text: null
   id: "DBUS_MAPPING_ERROR"
   approved: false
+
 - code: "10508"
   title: "REPRINT WITHOUT HISTORY"
   text: null
   id: "REPRINT_WITHOUT_HISTORY"
   approved: false
+
 - code: "10509"
   title: "MISSING WIZARD DATA"
   text: "The wizard did not finish successfully!"
   id: "MISSING_WIZARD_DATA"
   approved: false
+
 - code: "10510"
   title: "MISSING CALIBRATION DATA"
   text: "The calibration did not finish successfully!"
   id: "MISSING_CALIBRATION_DATA"
   approved: false
+
 - code: "10511"
   title: "MISSING UVCALIBRATION DATA"
   text: "The automatic UV LED calibration did not finish successfully!"
   id: "MISSING_UVCALIBRATION_DATA"
   approved: false
+
 - code: "10512"
   title: "MISSING UVPWM SETTINGS"
   text: null
   id: "MISSING_UVPWM_SETTINGS"
   approved: false
+
 - code: "10513"
   title: "FAILED UPDATE CHANNEL SET"
   text: "Cannot set update channel"
   id: "FAILED_UPDATE_CHANNEL_SET"
   approved: false
+
 - code: "10514"
   title: "FAILED UPDATE CHANNEL GET"
   text: null
   id: "FAILED_UPDATE_CHANNEL_GET"
   approved: false
+
 - code: "10515"
   title: "WARNING ESCALATION"
   text: null
   id: "WARNING_ESCALATION"
   approved: false
+
 - code: "10516"
   title: "NOT ENOUGH INTERNAL SPACE"
   text: null
   id: "NOT_ENOUGH_INTERNAL_SPACE"
   approved: false
+
 - code: "10517"
   title: "ADMIN NOT AVAILABLE"
   text: null
   id: "ADMIN_NOT_AVAILABLE"
   approved: false
+
 - code: "10518"
   title: "FILE NOT FOUND"
   text: "Cannot find a file!"
   id: "FILE_NOT_FOUND"
   approved: false
+
 - code: "10519"
   title: "INVALID EXTENSION"
   text: "File has an invalid extension!"
   id: "INVALID_EXTENSION"
   approved: false
+
 - code: "10520"
   title: "FILE ALREADY EXISTS"
   text: "File already exists!"
   id: "FILE_ALREADY_EXISTS"
   approved: false
+
 - code: "10521"
   title: "INVALID PROJECT"
   text: "The project file is invalid!"
   id: "INVALID_PROJECT"
   approved: false
+
 - code: "10522"
   title: "WIZARD NOT CANCELABLE"
   text: "This wizard cannot be canceled"
   id: "WIZARD_NOT_CANCELABLE"
   approved: false
+
+
+
+
+# WARNINGS       107xx   # Category-less warnings
 - code: "10700"
   title: "NONE WARNING"
   text: "No warning"
   id: "NONE_WARNING"
   approved: false
+
 - code: "10701"
   title: "UNKNOWN WARNING"
   text: "Unknown warning"
   id: "UNKNOWN_WARNING"
   approved: false
+
 - code: "10702"
   title: "AMBIENT TOO HOT WARNING"
   text: null
   id: "AMBIENT_TOO_HOT_WARNING"
   approved: false
+
 - code: "10703"
   title: "AMBIENT TOO COLD WARNING"
   text: null
   id: "AMBIENT_TOO_COLD_WARNING"
   approved: false
+
 - code: "10704"
   title: "PRINTING DIRECTLY WARNING"
   text: null
   id: "PRINTING_DIRECTLY_WARNING"
   approved: false
+
 - code: "10705"
   title: "PRINTER MODEL MISMATCH WARNING"
   text: null
   id: "PRINTER_MODEL_MISMATCH_WARNING"
   approved: false
+
 - code: "10706"
   title: "RESIN NOT ENOUGH WARNING"
   text: null
   id: "RESIN_NOT_ENOUGH_WARNING"
   approved: false
+
 - code: "10707"
   title: "PROJECT SETTINGS MODIFIED WARNING"
   text: null
   id: "PROJECT_SETTINGS_MODIFIED_WARNING"
   approved: false
+
 - code: "10708"
   title: "PERPARTES NOAVAIL WARNING"
   text: null
   id: "PERPARTES_NOAVAIL_WARNING"
   approved: false
+
 - code: "10709"
   title: "MASK NOAVAIL WARNING"
   text: null
   id: "MASK_NOAVAIL_WARNING"
   approved: false
+
 - code: "10710"
   title: "OBJECT TRUNCATED WARNING"
   text: null

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include prusaerrors/sl1/errors.yaml

--- a/prusaerrors/shared/codes.py
+++ b/prusaerrors/shared/codes.py
@@ -8,8 +8,11 @@ Base classes for SL1 errors and warnings
 
 import functools
 import json
+import re
 from enum import unique, IntEnum
+from pathlib import Path
 from typing import Optional, TextIO, Dict
+import yaml
 
 
 @unique
@@ -46,8 +49,17 @@ class Code:
     """
     Code class holds error code information
     """
+
     # pylint: disable = too-many-arguments
-    def __init__(self, printer: Printer, category: Category, error: int, message: Optional[str], approved: bool):
+    def __init__(
+            self,
+            printer: Printer,
+            category: Category,
+            error: int,
+            title: Optional[str],
+            message: Optional[str],
+            approved: bool,
+    ):
         if printer.value < 0 or printer.value > 99:
             raise ValueError(f"Printer class {printer} out of range")
         if category.value < 0 or category.value > 9:
@@ -59,6 +71,7 @@ class Code:
         self._printer = printer
         self._category = category
         self._error = error
+        self._title = title
         self._message = message
         self._approved = approved
 
@@ -117,6 +130,14 @@ class Code:
         return self._category
 
     @property
+    def title(self) -> str:
+        """
+        Get error title
+
+        :return: Error category title
+        """
+
+    @property
     def message(self) -> str:
         """
         Get error message
@@ -146,7 +167,9 @@ class Code:
         return self.code == other.code
 
     def __repr__(self):
-        return f"Code: {self.code} = {str(self.printer)}:{str(self.category)}:{self.error} - {self.message}"
+        return (
+            f"Code: {self.code} = {str(self.printer)}:{str(self.category)}:{self.error} - {self._title}:{self.message}"
+        )
 
     def __str__(self):
         return self.code
@@ -228,7 +251,7 @@ class Codes:
         for code in cls.get_codes().values():
             if code.message and code.approved:
                 # file.write('\t{"' + code.code + '", "' + code.message + '"},\n')
-                file.write(f'\t{code.raw_code}, {code.raw_message},\n')
+                file.write(f"\t{code.raw_code}, {code.raw_message},\n")
 
         file.write("};\n")
 
@@ -246,7 +269,7 @@ class Codes:
 
         for code in cls.get_codes().values():
             if code.message:
-                file.write(f'\t\t{code.raw_code}: qsTr({code.raw_message}),\n')
+                file.write(f"\t\t{code.raw_code}: qsTr({code.raw_message}),\n")
 
         file.write("\t}\n")
         file.write("}\n")
@@ -262,7 +285,7 @@ class Codes:
         file.write("// Generated translation string definitions for all defined error messages\n")
         for code in cls.get_codes().values():
             if code.message:
-                file.write(f'QT_TR_NOOP({code.raw_message});\n')
+                file.write(f"QT_TR_NOOP({code.raw_message});\n")
 
     @classmethod
     def dump_google_docs(cls, file: TextIO) -> None:
@@ -286,6 +309,23 @@ class Codes:
             category = f"{c2docs[code.category]}\t{code.category.value}"
             file.write(f'SL1\t10\t{category}\t{code.error}\t"{name}"\t"{message}"\t{code.code}\n')
 
+    @classmethod
+    def dump_yaml(cls, file: TextIO) -> None:
+        """
+        Dump YAML representation of error codes suitable for Codes class creation using a decorator.
+
+        :param file: Where to dump
+        :return: None
+        """
+        codes = []
+
+        for name, code in cls.get_codes().items():
+            codes.append(
+                {"code": code.raw_code, "title": name, "text": code.message, "id": name, "approved": code.approved,}
+            )
+
+        yaml.dump({"Errors": codes}, file, sort_keys=False)
+
 
 def unique_codes(cls):
     """
@@ -301,3 +341,25 @@ def unique_codes(cls):
         used.add(code.code)
 
     return cls
+
+
+def yaml_codes(src_path: Path):
+    """
+    Add code definitions from YAML source
+    """
+
+    def decor(cls):
+        with src_path.open("r") as src_file:
+            data = yaml.safe_load(src_file)
+        assert "Errors" in data
+
+        code_re = re.compile(r"^(?P<printer>[0-9][0-9])(?P<category>[0-9])(?P<error>[0-9][0-9])$")
+        for entry in data["Errors"]:
+            code_parts = code_re.match(entry["code"]).groupdict()
+            printer = Printer(int(code_parts["printer"]))
+            category = Category(int(code_parts["category"]))
+            error = int(code_parts["error"])
+            setattr(cls, entry["id"], Code(printer, category, error, entry["title"], entry["text"], entry["approved"]))
+        return cls
+
+    return decor

--- a/prusaerrors/sl1/codes.py
+++ b/prusaerrors/sl1/codes.py
@@ -9,8 +9,9 @@ Warning: The codes has not yet been officially approved.
 """
 
 import builtins
+from pathlib import Path
 
-from prusaerrors.shared.codes import Code, Category, unique_codes, Codes, Printer
+from prusaerrors.shared.codes import unique_codes, Codes, yaml_codes
 
 if "_" not in vars(builtins):
 
@@ -19,149 +20,13 @@ if "_" not in vars(builtins):
 
 
 @unique_codes
+@yaml_codes(Path(__file__).parent / "errors.yaml")
 class Sl1Codes(Codes):
     """
     Error, exception and warning identification codes
+
+    Content is loaded by yaml_codes decorator
     """
-
-    PRINTER = Printer.SL1
-
-    # Mechanical
-    TILT_HOME_FAILED = Code(PRINTER, Category.MECHANICAL, 1, None, False)
-    TOWER_HOME_FAILED = Code(PRINTER, Category.MECHANICAL, 2, None, False)
-    TOWER_MOVE_FAILED = Code(PRINTER, Category.MECHANICAL, 3, None, False)
-    FAN_FAILED = Code(PRINTER, Category.MECHANICAL, 6, None, False)
-    RESIN_TOO_LOW = Code(PRINTER, Category.MECHANICAL, 8, None, False)
-    RESIN_TOO_HIGH = Code(PRINTER, Category.MECHANICAL, 9, None, False)
-    NOT_MECHANICALLY_CALIBRATED = Code(PRINTER, Category.MECHANICAL, 13, None, False)
-    TOWER_ENDSTOP_NOT_REACHED = Code(PRINTER, Category.MECHANICAL, 14, _("Failed to reach tower endstop"), False)
-    TILT_ENDSTOP_NOT_REACHED = Code(PRINTER, Category.MECHANICAL, 15, _("Failed to reach tilt endstop"), False)
-    TOWER_AXIS_CHECK_FAILED = Code(
-        PRINTER,
-        Category.MECHANICAL,
-        18,
-        _(
-            "Tower axis check failed!\n\n"
-            "Current position: %d nm\n\n"
-            "Please check if the ballscrew can move smoothly in its entire range."
-        ),
-        False,
-    )
-    TILT_AXIS_CHECK_FAILED = Code(
-        PRINTER,
-        Category.MECHANICAL,
-        19,
-        _(
-            "Tilt axis check failed!\n\n"
-            "Current position: %d steps\n\n"
-            "Please check if the tilt can move smoothly in its entire range."
-        ),
-        False,
-    )
-    DISPLAY_TEST_FAILED = Code(PRINTER, Category.MECHANICAL, 20, _("Display test failed."), False)
-    INVALID_TILT_ALIGN_POSITION = Code(PRINTER, Category.MECHANICAL, 21, _("Invalid tilt align position"), False)
-    FAN_RPM_OUT_OF_TEST_RANGE = Code(
-        PRINTER,
-        Category.MECHANICAL,
-        22,
-        _(
-            "RPM of %(fan)s not in range!\n\n"
-            "Please check if the fan is connected correctly.\n\n"
-            "RPM data: %(rpm)s\n"
-            "Average: %(avg)s\n"
-            "Fan error: %(fanError)s"
-        ),
-        False,
-    )
-    TOWER_BELOW_SURFACE = Code(
-        PRINTER,
-        Category.MECHANICAL,
-        23,
-        _("Tower not at the expected position.\n\n" "Is the platform and tank secured in correct position?\n\n"),
-        False,
-    )
-
-    # Temperature
-    TEMP_SENSOR_FAILED = Code(PRINTER, Category.TEMPERATURE, 5, None, False)
-    UVLED_HEAT_SINK_FAILED = Code(
-        PRINTER, Category.TEMPERATURE, 6, _("UV LED overheating! Check proper heatsink installation."), False
-    )
-
-    # Connectivity
-    MQTT_SEND_FAILED = Code(PRINTER, Category.CONNECTIVITY, 1, _("Cannot send factory config to MQTT!"), False)
-    NOT_CONNECTED_TO_NETWORK = Code(PRINTER, Category.CONNECTIVITY, 2, None, False)
-    CONNECTION_FAILED = Code(PRINTER, Category.CONNECTIVITY, 3, None, False)
-    DOWNLOAD_FAILED = Code(PRINTER, Category.CONNECTIVITY, 4, None, False)
-
-    # Electrical
-    MOTION_CONTROLLER_WRONG_REVISION = Code(
-        PRINTER,
-        Category.ELECTRICAL,
-        1,
-        _("Wrong revision of the motion controller. Please replace it or contact our support."),
-        False,
-    )
-    MOTION_CONTROLLER_EXCEPTION = Code(PRINTER, Category.ELECTRICAL, 6, None, False)
-    RESIN_SENSOR_FAILED = Code(PRINTER, Category.ELECTRICAL, 7, None, False)
-    NOT_UV_CALIBRATED = Code(PRINTER, Category.ELECTRICAL, 8, None, False)
-    UVLED_VOLTAGE_DIFFER_TOO_MUCH = Code(
-        PRINTER, Category.ELECTRICAL, 9, _("UV LED voltages differ too much. Possibly LED module is broken."), False
-    )
-    SOUND_TEST_FAILED = Code(PRINTER, Category.ELECTRICAL, 10, _("Speaker is broken"), False)
-
-    # System
-    NONE = Code(PRINTER, Category.SYSTEM, 0, _("No problem"), False)
-    UNKNOWN = Code(
-        PRINTER,
-        Category.SYSTEM,
-        1,
-        _(
-            "An unexpected error has occurred :-(.\n\n"
-            "If the SL1 is printing, current job will be finished.\n\n"
-            "You can turn the printer off by pressing the front power button.\n\n"
-            "Please follow the instructions in Chapter 3.1 in the handbook to learn how to save a log file. "
-            "Please send the log to us and help us improve the printer.\n\n"
-            "Thank you!"
-        ),
-        False,
-    )
-    PRELOAD_FAILED = Code(PRINTER, Category.SYSTEM, 3, _("Image preloader did not finish successfully!"), False)
-    PROJECT_FAILED = Code(PRINTER, Category.SYSTEM, 4, None, False)
-    CONFIG_EXCEPTION = Code(PRINTER, Category.SYSTEM, 5, _("Failed to read configuration file"), False)
-    NOT_AVAILABLE_IN_STATE = Code(PRINTER, Category.SYSTEM, 6, None, False)
-    DBUS_MAPPING_ERROR = Code(PRINTER, Category.SYSTEM, 7, None, False)
-    REPRINT_WITHOUT_HISTORY = Code(PRINTER, Category.SYSTEM, 8, None, False)
-    MISSING_WIZARD_DATA = Code(PRINTER, Category.SYSTEM, 9, _("The wizard did not finish successfully!"), False)
-    MISSING_CALIBRATION_DATA = Code(
-        PRINTER, Category.SYSTEM, 10, _("The calibration did not finish successfully!"), False
-    )
-    MISSING_UVCALIBRATION_DATA = Code(
-        PRINTER, Category.SYSTEM, 11, _("The automatic UV LED calibration did not finish successfully!"), False
-    )
-    MISSING_UVPWM_SETTINGS = Code(PRINTER, Category.SYSTEM, 12, None, False)
-    FAILED_UPDATE_CHANNEL_SET = Code(PRINTER, Category.SYSTEM, 13, _("Cannot set update channel"), False)
-    FAILED_UPDATE_CHANNEL_GET = Code(PRINTER, Category.SYSTEM, 14, None, False)
-    WARNING_ESCALATION = Code(PRINTER, Category.SYSTEM, 15, None, False)
-    NOT_ENOUGH_INTERNAL_SPACE = Code(PRINTER, Category.SYSTEM, 16, None, False)
-    ADMIN_NOT_AVAILABLE = Code(PRINTER, Category.SYSTEM, 17, None, False)
-    FILE_NOT_FOUND = Code(PRINTER, Category.SYSTEM, 18, _("Cannot find a file!"), False)
-    INVALID_EXTENSION = Code(PRINTER, Category.SYSTEM, 19, _("File has an invalid extension!"), False)
-    FILE_ALREADY_EXISTS = Code(PRINTER, Category.SYSTEM, 20, _("File already exists!"), False)
-    INVALID_PROJECT = Code(PRINTER, Category.SYSTEM, 21, _("The project file is invalid!"), False)
-    WIZARD_NOT_CANCELABLE = Code(PRINTER, Category.SYSTEM, 22, _("This wizard cannot be canceled"), False)
-
-    # Warnings
-    NONE_WARNING = Code(PRINTER, Category.WARNINGS, 0, _("No warning"), False)
-    UNKNOWN_WARNING = Code(PRINTER, Category.WARNINGS, 1, _("Unknown warning"), False)
-    AMBIENT_TOO_HOT_WARNING = Code(PRINTER, Category.WARNINGS, 2, None, False)
-    AMBIENT_TOO_COLD_WARNING = Code(PRINTER, Category.WARNINGS, 3, None, False)
-    PRINTING_DIRECTLY_WARNING = Code(PRINTER, Category.WARNINGS, 4, None, False)
-    PRINTER_MODEL_MISMATCH_WARNING = Code(PRINTER, Category.WARNINGS, 5, None, False)
-    RESIN_NOT_ENOUGH_WARNING = Code(PRINTER, Category.WARNINGS, 6, None, False)
-    PROJECT_SETTINGS_MODIFIED_WARNING = Code(PRINTER, Category.WARNINGS, 7, None, False)
-    PERPARTES_NOAVAIL_WARNING = Code(PRINTER, Category.WARNINGS, 8, None, False)
-    MASK_NOAVAIL_WARNING = Code(PRINTER, Category.WARNINGS, 9, None, False)
-    OBJECT_TRUNCATED_WARNING = Code(PRINTER, Category.WARNINGS, 10, None, False)
 
     @classmethod
     def get(cls, code: str):
@@ -176,4 +41,4 @@ class Sl1Codes(Codes):
         try:
             return super().get(code)
         except KeyError:
-            return cls.UNKNOWN
+            return cls.UNKNOWN  # pylint: disable=no-member

--- a/prusaerrors/sl1/errors.yaml
+++ b/prusaerrors/sl1/errors.yaml
@@ -1,0 +1,1 @@
+../../10_SL1/errors.yaml

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,5 @@ setup(
     url="https://github.com/prusa3d/Prusa-Error-Codes",
     license="GNU General Public License v3 or later (GPLv3+)",
     classifiers=["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"],
+    include_package_data=True,
 )

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -16,7 +16,7 @@ from prusaerrors.shared.codes import unique_codes, Codes, Printer, Code, Categor
 @unique_codes
 class TestCodes(Codes):
     PRINTER = Printer.UNKNOWN
-    NONE = Code(PRINTER, Category.SYSTEM, 0, "No problem", True)
+    NONE = Code(PRINTER, Category.SYSTEM, 0, "No title", "No problem", True)
 
 
 class TestErrors(unittest.TestCase):


### PR DESCRIPTION
- Create `Sl1Codes` class content by decorator. This should be compatible
with direct declaration in codes.py. Only difference is that pyyaml is
required at runtime of Python users and compile time of `QML/C++/others`
dump users.
- Add yaml export support
- Test of integration: https://gitlab.com/prusa3d/sl1/meta-sl1/-/merge_requests/295