### PR TITLE
NOT_AVAILABLE_IN_STATE(10506): text update

### DIFF
--- a/10_SL1/errors.yaml
+++ b/10_SL1/errors.yaml
@@ -377,7 +377,7 @@ Errors:
 
 - code: "10506"
   title: "PRINTER IS BUSY"
-  text: "Cannot run this action, wait until the printer finishes the previous action."
+  text: "Another action is already running. Finish this action directly using the printer's touchscreen."
   id: "NOT_AVAILABLE_IN_STATE"
   approved: true
 


### PR DESCRIPTION
This error is used currently only in web UI when one-click should be shown but printer is not ready to print. In this case wizard is started so user cannot start a print from web UI. This is better description recommending to the user to check the printer physically and finish the wizard.