### PR TITLE
OLD_EXPO_PANEL(10548): new code

### DIFF
--- a/10_SL1/errors.yaml
+++ b/10_SL1/errors.yaml
@@ -641,6 +641,15 @@ Errors:
   id: "LANGUAGE_ERROR"
   approved: false
 
+- code: "10548"
+  title: "OLD EXPO PANEL"
+  text: "Exposure screen that is currently connected has already been used on this printer. This screen was last used for approximately %(counter_h)d hours.
+
+
+    If you do not want to use this screen: turn the printer off, replace the screen and turn the printer back on."
+  id: "OLD_EXPO_PANEL"
+  approved: false
+
 # BOOTLOADER     xx6xx   #
 - code: "10601"
   title: "BOOTED SLOT CHANGED"


### PR DESCRIPTION
- error which pops up when user replaces exposure screen which already has been in the printer previously