### PR TITLE
Add SYSTEM_SERVICE_CRASHED error to indicate crashed D-Bus services

### DIFF
--- a/10_SL1/errors.yaml
+++ b/10_SL1/errors.yaml
@@ -657,6 +657,16 @@ Errors:
   id: "OLD_EXPO_PANEL"
   approved: false
 
+- code: "10549"
+  # A generic error for crashed DBus services, parameters should specify which.
+  title: "SYSTEM SERVICE CRASHED"
+  text: "Something went wrong with the printer firmware. Please contact our support and do not forget to attach the logs.
+  
+  Crashed services are immediately started again. If, despite that, the printer does not behave correctly, try restarting it.
+  "
+  id: "SYSTEM_SERVICE_CRASHED"
+  approved: false
+
 # BOOTLOADER     xx6xx   #
 - code: "10601"
   title: "BOOTED SLOT CHANGED"


### PR DESCRIPTION
The error will be shown when any of the firmware D-Bus services, that are expected to always be available, unregisters from the bus - indicating that it probably crashed.

Part of: SL1SW-544