### PR TITLE
Numeric device ids

### DIFF
--- a/10_SL1/errors.yaml
+++ b/10_SL1/errors.yaml
@@ -161,11 +161,11 @@ Errors:
     Check if the fan is connected correctly.
 
 
-    RPM data: %(rpm)s
+    RPM data: %(min_rpm)d - %(max_rpm)d
 
-    Average: %(avg)s"
+    Average: %(avg_rpm)d (%(lower_bound_rpm)d - %(upper_bound_rpm)d), error: %(error)d"
   id: "FAN_RPM_OUT_OF_TEST_RANGE_ID"
-  approved: true
+  approved: false
 
 # TEMPERATURE    102xx   # Temperature measurement, thermistors, heating
 
@@ -212,7 +212,7 @@ Errors:
 
 - code: "10211"
   title: "TEMPERATURE OUT OF RANGE"
-  text: "%(sensor__map_HardwareDeviceId)s not in range!
+  text: "Reading of %(sensor__map_HardwareDeviceId)s not in range!
 
 
     Measured temperature: %(temperature).1f °C, allowed range: %(min)d - %(max)d °C.

--- a/10_SL1/errors.yaml
+++ b/10_SL1/errors.yaml
@@ -36,6 +36,7 @@ Errors:
   id: "TOWER_MOVE_FAILED"
   approved: true
 
+# Deprecated, use FAN_FAILED_ID
 - code: "10106"
   title: "FAN FAILURE"
   text: "Incorrect RPM reading of the %(failed_fans_text)s fan. Please check its wiring and connection."
@@ -108,6 +109,7 @@ Errors:
   id: "INVALID_TILT_ALIGN_POSITION"
   approved: false
 
+# Deprecated, use FAN_RPM_OUT_OF_TEST_RANGE_ID
 - code: "10122"
   title: "FAN RPM OUT OF TEST RANGE"
   text: "RPM of %(fan)s not in range!
@@ -145,9 +147,29 @@ Errors:
   id: "CLEANING_ADAPTOR_MISSING"
   approved: false
 
+- code: "10126"
+  title: "FAN FAILURE"
+  text: "Incorrect RPM reading of the %(fan__map_HardwareDeviceId)s. Please check its wiring and connection."
+  id: "FAN_FAILED_ID"
+  approved: true
 
+- code: "10127"
+  title: "FAN RPM OUT OF TEST RANGE"
+  text: "RPM of %(fan__map_HardwareDeviceId)s not in range!
+
+
+    Check if the fan is connected correctly.
+
+
+    RPM data: %(rpm)s
+
+    Average: %(avg)s"
+  id: "FAN_RPM_OUT_OF_TEST_RANGE_ID"
+  approved: true
 
 # TEMPERATURE    102xx   # Temperature measurement, thermistors, heating
+
+# Deprecated, use TEMP_SENSOR_FAILED_ID
 - code: "10205"
   title: "TEMPERATURE SENSOR FAILED"
   text: "The %(sensor)s sensor failed. Check the wiring and connection."
@@ -167,6 +189,7 @@ Errors:
   id: "A64_OVERHEAT"
   approved: false
 
+# Deprecated, use TEMPERATURE_OUT_OF_RANGE_ID
 - code: "10208"
   title: "TEMPERATURE OUT OF RANGE"
   text: "%(sensor)s not in range!
@@ -181,6 +204,19 @@ Errors:
   id: "UV_TEMP_SENSOR_FAILED"
   approved: true
 
+- code: "10210"
+  title: "TEMPERATURE SENSOR FAILED"
+  text: "The %(sensor__map_HardwareDeviceId)s sensor failed. Check the wiring and connection."
+  id: "TEMP_SENSOR_FAILED_ID"
+  approved: true
+
+- code: "10211"
+  title: "TEMPERATURE OUT OF RANGE"
+  text: "%(sensor__map_HardwareDeviceId)s not in range!
+    Measured temperature: %(temperature).1f °C.
+    Keep the printer out of direct sunlight at room temperature (18 - 32 °C)."
+  id: "TEMPERATURE_OUT_OF_RANGE_ID"
+  approved: true
 
 # ELECTRICAL     103xx   # Electrical, MINDA, FINDA, Motion Controller, …
 - code: "10301"

--- a/10_SL1/errors.yaml
+++ b/10_SL1/errors.yaml
@@ -213,10 +213,14 @@ Errors:
 - code: "10211"
   title: "TEMPERATURE OUT OF RANGE"
   text: "%(sensor__map_HardwareDeviceId)s not in range!
-    Measured temperature: %(temperature).1f °C.
+
+
+    Measured temperature: %(temperature).1f °C, allowed range: %(min)d - %(max)d °C.
+
+
     Keep the printer out of direct sunlight at room temperature (18 - 32 °C)."
   id: "TEMPERATURE_OUT_OF_RANGE_ID"
-  approved: true
+  approved: false
 
 # ELECTRICAL     103xx   # Electrical, MINDA, FINDA, Motion Controller, …
 - code: "10301"

--- a/prusaerrors/shared/codes.py
+++ b/prusaerrors/shared/codes.py
@@ -344,6 +344,7 @@ def unique_codes(cls):
 
     return cls
 
+
 def unique_titles(cls):
     """
     Class decorator requiring unique title definition inside the class

--- a/prusaerrors/sl1/codes.py
+++ b/prusaerrors/sl1/codes.py
@@ -11,7 +11,7 @@ Warning: The codes has not yet been officially approved.
 import builtins
 from pathlib import Path
 
-from prusaerrors.shared.codes import unique_codes, unique_titles, Codes, yaml_codes
+from prusaerrors.shared.codes import unique_codes, Codes, yaml_codes
 
 if "_" not in vars(builtins):
 
@@ -20,7 +20,6 @@ if "_" not in vars(builtins):
 
 
 @unique_codes
-@unique_titles
 @yaml_codes(Path(__file__).parent / "errors.yaml")
 class Sl1Codes(Codes):
     """


### PR DESCRIPTION
- Minor fixes
- Fan, temp devices identified by mapped integers instead of direct translated strings. This is achieved by introducing new error codes that serve the same purpose as the old ones. Old ones are marked as deprecated. This solution was chosen to avoid possible errors and overall hassle with versioning, backward compatibility and translations.
- New error codes are improved in terms of parameter structure and availability of range limits.