### PR TITLE
Update with changes made in Prusa-Firmware-Buddy

### DIFF
--- a/12_MINI/errors_list.h
+++ b/12_MINI/errors_list.h
@@ -21,6 +21,7 @@ typedef enum : uint16_t {
     ERR_TEMPERATURE_MIN_NOZZLE,
 
     ERR_ELECTRO = 300,
+    ERR_ELECTRO_HOMING_ERROR = 301,
 
     ERR_CONNECT = 400,
 
@@ -85,4 +86,10 @@ static constexpr err_t error_list[] = {
         // r=5, c=20
         N_("Check the print head thermistor wiring for possible damage."),
         ERR_TEMPERATURE_MIN_NOZZLE },
+
+    // r=1, c=19
+    { N_("HOMING ERROR"),
+        // r=5, c=20
+        N_("SuperPINDA sensor is probably broken or disconnected, could not home Z-axis properly."),
+        ERR_ELECTRO_HOMING_ERROR },
 };


### PR DESCRIPTION
These changes were made in the subrepo in Prusa-Firmware-Buddy.

They can be viewed with:
```bash
git subrepo branch --force lib/Prusa-Error-Codes
git log subrepo/lib/Prusa-Error-Codes
```
However, they have a wrong parent. `git-subrepo` seems to be messed up in some way I wasn't able to figure out. These commits are extracted from that branch and rebased on current master. After this is merged (barring something less forceful won't get us into a consistent state) the plan is to probably do a `git subrepo clone --force ...` which I've tested will make things right again.