### PR TITLE
Fix few issues

### DIFF
--- a/04_MMU/error-codes.yaml
+++ b/04_MMU/error-codes.yaml
@@ -115,7 +115,7 @@ Errors:
   title: "WARNING TMC TOO HOT"
   text: "TMC driver for the Pulley motor is almost overheating. Make sure there is sufficient airflow near the MMU board."
   text_short: "More details online."
-  action: [Continue, ResetMMU]
+  action: [Continue,ResetMMU]
   id: "WARNING_TMC_PULLEY_TOO_HOT"
   approved: true
 
@@ -123,7 +123,7 @@ Errors:
   title: "WARNING TMC TOO HOT"
   text: "TMC driver for the Selector motor is almost overheating. Make sure there is sufficient airflow near the MMU board."
   text_short: "More details online."
-  action: [Continue, ResetMMU]
+  action: [Continue,ResetMMU]
   id: "WARNING_TMC_SELECTOR_TOO_HOT"
   approved: true
 
@@ -131,7 +131,7 @@ Errors:
   title: "WARNING TMC TOO HOT"
   text: "TMC driver for the Idler motor is almost overheating. Make sure there is sufficient airflow near the MMU board."
   text_short: "More details online."
-  action: [Continue, ResetMMU]
+  action: [Continue,ResetMMU]
   id: "WARNING_TMC_IDLER_TOO_HOT"
   approved: true
 
@@ -307,14 +307,14 @@ Errors:
 - code: "04501"
   title: "FIL. ALREADY LOADED"
   text: "Cannot perform the action, filament is already loaded. Unload it first."
-  action: [Unload, Continue]
+  action: [Unload,Continue]
   id: "FILAMENT_ALREADY_LOADED"
   approved: true
 
 - code: "04502"
   title: "INVALID TOOL"
   text: "Requested filament tool is not available on this hardware. Check the G-code for tool index out of range (T0-T4)."
-  action: [StopPrint, ResetMMU]
+  action: [StopPrint,ResetMMU]
   id: "INVALID_TOOL"
   approved: true
 

--- a/04_MMU/error-codes.yaml
+++ b/04_MMU/error-codes.yaml
@@ -285,7 +285,7 @@ Errors:
   text: "MMU MCU detected a 5V undervoltage. There might be an issue with the electronics. Check the wiring and connectors"
   text_short: "More details online."
   action: [ResetMMU]
-  id: "ERR_ELECTRICAL_MCU_UNDERVOLTAGE_VCC"
+  id: "MCU_UNDERVOLTAGE_VCC"
   approved: true
 
 # CONNECTIVITY

--- a/04_MMU/error-codes.yaml
+++ b/04_MMU/error-codes.yaml
@@ -281,7 +281,7 @@ Errors:
   approved: false
 
 - code: "04306"
-  title: "MMU MCU UNDERVOLTAGE"
+  title: "MMU MCU UNDERPOWER"
   text: "MMU MCU detected a 5V undervoltage. There might be an issue with the electronics. Check the wiring and connectors"
   text_short: "More details online."
   action: [ResetMMU]
@@ -327,7 +327,8 @@ Errors:
 
 - code: "04504"
   title: "MMU FW UPDATE NEEDED"
-  text: "MMU FW version is incompatible with printer FW.Update to compatible version."
+  text: "The MMU firmware version is incompatible with the printer's FW. Update to compatible version."
+  text_short: "MMU FW version is incompatible with printer FW.Update to version 2.1.9."
   action: [ResetMMU,DisableMMU]
   id: "FW_UPDATE_NEEDED"
   approved: true

--- a/04_MMU/error-codes.yaml
+++ b/04_MMU/error-codes.yaml
@@ -281,7 +281,7 @@ Errors:
   approved: false
 
 - code: "04306"
-  title: "MMU MCU UNDERPOWER"
+  title: "MMU MCU UNDERVOLTAGE"
   text: "MMU MCU detected a 5V undervoltage. There might be an issue with the electronics. Check the wiring and connectors"
   text_short: "More details online."
   action: [ResetMMU]

--- a/04_MMU/error-codes.yaml
+++ b/04_MMU/error-codes.yaml
@@ -30,7 +30,7 @@ Errors:
   approved: true
 
 - code: "04102"
-  title: "FINDA: FILAM. STUCK"
+  title: "FINDA FILAM. STUCK"
   text: "FINDA didn't switch off while unloading filament. Try unloading manually. Ensure filament can move and FINDA works."
   action: [Retry]
   id: "FINDA_FILAMENT_STUCK"
@@ -44,7 +44,7 @@ Errors:
   approved: true
 
 - code: "04104"
-  title: "FSENSOR: FIL. STUCK"
+  title: "FSENSOR FIL. STUCK"
   text: "Filament sensor didn't switch off while unloading filament. Ensure filament can move and the sensor works."
   action: [Retry]
   id: "FSENSOR_FILAMENT_STUCK"
@@ -327,7 +327,7 @@ Errors:
 
 - code: "04504"
   title: "MMU FW UPDATE NEEDED"
-  text: "The MMU reports its FW version incompatible with the printer's firmware. Make sure the MMU firmware is up to date."
+  text: "The MMU firmware version incompatible with the printer's FW. Update to compatible version."
   action: [ResetMMU,DisableMMU]
   id: "FW_UPDATE_NEEDED"
   approved: true

--- a/04_MMU/error-codes.yaml
+++ b/04_MMU/error-codes.yaml
@@ -327,7 +327,7 @@ Errors:
 
 - code: "04504"
   title: "MMU FW UPDATE NEEDED"
-  text: "The MMU firmware version incompatible with the printer's FW. Update to compatible version."
+  text: "MMU FW version is incompatible with printer FW.Update to compatible version."
   action: [ResetMMU,DisableMMU]
   id: "FW_UPDATE_NEEDED"
   approved: true

--- a/04_MMU/error-codes.yaml
+++ b/04_MMU/error-codes.yaml
@@ -37,7 +37,7 @@ Errors:
   approved: true
 
 - code: "04103"
-  title: "FSENSOR DIDNT TRIGGER"
+  title: "FSENSOR DIDNT TRIGG."
   text: "Filament sensor didn't trigger while loading the filament. Ensure the sensor is calibrated and the filament reached it."
   action: [Retry]
   id: "FSENSOR_DIDNT_TRIGGER"
@@ -209,7 +209,7 @@ Errors:
   approved: true
 
 - code: "04303"
-  title: "TMC UNDERVOLTAGE ERROR"
+  title: "TMC UNDERVOLTAGE ERR"
   text: "Not enough current for the Pulley TMC driver. There is probably an issue with the electronics. Check the wiring and connectors."
   text_short: "More details online."
   action: [ResetMMU]
@@ -217,7 +217,7 @@ Errors:
   approved: true
 
 - code: "04313"
-  title: "TMC UNDERVOLTAGE ERROR"
+  title: "TMC UNDERVOLTAGE ERR"
   text: "Not enough current for the Selector TMC driver. There is probably an issue with the electronics. Check the wiring and connectors."
   text_short: "More details online."
   action: [ResetMMU]
@@ -225,7 +225,7 @@ Errors:
   approved: true
 
 - code: "04323"
-  title: "TMC UNDERVOLTAGE ERROR"
+  title: "TMC UNDERVOLTAGE ERR"
   text: "Not enough current for the Idler TMC driver. There is probably an issue with the electronics. Check the wiring and connectors."
   text_short: "More details online."
   action: [ResetMMU]
@@ -305,7 +305,7 @@ Errors:
 
 # SYSTEM
 - code: "04501"
-  title: "FILAMENT ALREADY LOADED"
+  title: "FIL. ALREADY LOADED"
   text: "Cannot perform the action, filament is already loaded. Unload it first."
   action: [Unload, Continue]
   id: "FILAMENT_ALREADY_LOADED"
@@ -326,7 +326,7 @@ Errors:
   approved: true
 
 - code: "04504"
-  title: "FW UPDATE NEEDED"
+  title: "MMU FW UPDATE NEEDED"
   text: "The MMU reports its FW version incompatible with the printer's firmware. Make sure the MMU firmware is up to date."
   action: [ResetMMU,DisableMMU]
   id: "FW_UPDATE_NEEDED"


### PR DESCRIPTION
- Update titles to 20 chars max. Not only on MK3 lcd issue also on MK4
- All actions divided by `,` only. Spaces deleted.
  - Consistent format makes it easier to script around these codes
- Change `ERR_ELECTRICAL_MCU_UNDERVOLTAGE_VCC` to `MCU_UNDERVOLTAGE_VCC` as it is already declared as Electrical issue
```
# ELECTRICAL     xx3xx   # Electrical - TMC non-temperature-related errors
```

Counterpart for the Prusa-Firmware https://github.com/prusa3d/Prusa-Firmware/pull/4238 