### PR TITLE
Add iX and MK35 error codes.

### DIFF
--- a/16_iX/error-codes.yaml
+++ b/16_iX/error-codes.yaml
@@ -1,0 +1,435 @@
+---
+# Error codes list for Original Prusa iX printer
+# GitHub repo https://github.com/prusa3d/Prusa-Error-Codes
+# Printer code
+# IX             16xxx
+# Error categories
+# MECHANICAL     xx1xx   # Mechanical failures, engines XYZ, tower
+# TEMPERATURE    xx2xx   # Temperature measurement, thermistors, heating
+# ELECTRICAL     xx3xx   # Electrical, MINDA, FINDA, Motion Controller, …
+# CONNECTIVITY   xx4xx   # Connectivity - Wi - Fi, LAN, Prusa Connect Cloud
+# SYSTEM         xx5xx   # System - BSOD, ...
+# BOOTLOADER     xx6xx   #
+# WARNINGS       xx7xx   # Category-less warnings
+
+
+Errors:
+# XX103 reserved
+- code: "16201"
+  title: "PREHEAT ERROR"
+  text: "Check the heatbed heater & thermistor wiring for possible damage."
+  id: "BED_PREHEAT_ERROR"
+  approved: true
+- code: "16202"
+  title: "PREHEAT ERROR"
+  text: "Check the print head heater & thermistor wiring for possible damage."
+  id: "HOTEND_PREHEAT_ERROR"
+  approved: true
+- code: "16203"
+  title: "THERMAL RUNAWAY"
+  text: "Check the heatbed thermistor wiring for possible damage."
+  id: "BED_THERMAL_RUNAWAY"
+  approved: true
+- code: "16204"
+  title: "THERMAL RUNAWAY"
+  text: "Check the print head thermistor wiring for possible damage."
+  id: "HOTEND_THERMAL_RUNAWAY"
+  approved: true
+- code: "16205"
+  title: "MAXTEMP ERROR"
+  text: "Check the heatbed thermistor wiring for possible damage."
+  id: "BED_MAXTEMP_ERROR"
+  approved: true
+- code: "16206"
+  title: "MAXTEMP ERROR"
+  text: "Check the print head thermistor wiring for possible damage."
+  id: "HOTEND_MAXTEMP_ERROR"
+  approved: true
+- code: "16207"
+  title: "MINTEMP ERROR"
+  text: "Check the heatbed thermistor wiring for possible damage."
+  id: "BED_MINTEMP_ERROR"
+  approved: true
+- code: "16208"
+  title: "MINTEMP ERROR"
+  text: "Check the print head thermistor wiring for possible damage."
+  id: "HOTEND_MINTEMP_ERROR"
+  approved: true
+- code: "16209"
+  title: "TEMP NOT MATCHING"
+  text: "Measured temperature is not matching expected value. Check the thermistor is in contact with heatbed. In case of damage, replace it."
+  id: "BED_TEMP_NOT_MATCHING"
+  approved: true
+- code: "16210"
+  title: "TEMP NOT MATCHING"
+  text: "Measured temperature is not matching expected value. Check the thermistor is in contact with hotend. In case of damage, replace it."
+  id: "HOTEND_TEMP_NOT_MATCHING"
+  approved: true
+- code: "16211"
+  title: "HEATBREAK MINTEMP ERROR"
+  text: "Check the heatbreak thermistor wiring for possible damage."
+  id: "HEATBREAK_MINTEMP_ERR"
+  approved: true
+- code: "16212"
+  title: "HEATBREAK MAXTEMP ERROR"
+  text: "Check the heatbreak thermistor wiring for possible damage."
+  id: "HEATBREAK_MAXTEMP_ERR"
+  approved: true
+- code: "16250"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d:\nDamaged tile or wiring.\nFollow online guide to diagnose."
+  id: "MB_HEATER_DISCONNECTED"
+  approved: false
+- code: "16251"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d:\nDamaged tile or wiring.\nFollow online guide to diagnose."
+  id: "MB_HEATER_SHORT"
+  approved: false
+- code: "16252"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d: \nTemperature measurement error; thermistor may be faulty."
+  id: "MB_MINTEMP_ERR"
+  approved: false
+- code: "16253"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d: \nTemperature measurement error; thermistor may be faulty."
+  id: "MB_MAXTEMP_ERR"
+  approved: false
+- code: "16254"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d: \nUnexpected temperature drop detected."
+  id: "MB_DROP_TEMP"
+  approved: false 
+- code: "16255"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d:\n Unexpected temperature peak detected."
+  id: "MB_PEAK_TEMP"
+  approved: false 
+- code: "16256"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d:\nPreheat error."
+  id: "MB_PREHEAT_ERR"
+  approved: false 
+- code: "16257"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d:\nTest heating error."
+  id: "MB_TEST_HEATING_ERR"
+  approved: false 
+- code: "16258"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed connector no. %d:\nNothing should be connected here."
+  id: "MB_HEATER_CONNECTED"
+  approved: false
+- code: "16301"
+  title: "HOMING ERROR Z"
+  text: "Failed to home the extruder in Z-axis, make sure the loadcell is working."
+  id: "HOMING_ERROR_Z"
+  approved: true
+- code: "16302"
+  title: "MODULAR BED ERROR"
+  text: "Overcurrent detected."
+  id: "MB_OVERCURRENT"
+  approved: false
+- code: "16303"
+  title: "MODULAR BED ERROR"
+  text: "Unexpected invalid current."
+  id: "MB_INVALID_CURRENT"
+  approved: false
+- code: "16304"
+  title: "HOMING ERROR X"
+  text: "Failed to home the extruder in X-axis, make sure there is no obstacle on X-axis."
+  id: "HOMING_ERROR_X"
+  approved: true
+- code: "16305"
+  title: "HOMING ERROR Y"
+  text: "Failed to home the extruder in Y-axis, make sure there is no obstacle on Y-axis."
+  id: "HOMING_ERROR_Y"
+  approved: true
+- code: "16306"
+  title: "USB PORT OVERCURRENT"
+  text: "Overcurrent detected on USB port."
+  id: "USB_HOST_OVERCURRENT"
+  approved: true
+- code: "16307"
+  title: "USB DEVICE OVERCURRENT"
+  text: "Overcurrent detected on connected USB device, disconnect it."
+  id: "USB_DEVICE_OVERCURRENT"
+  approved: true
+- code: "16308"
+  title: "NOZZLE HEATER OVERCURRENT"
+  text: "Overcurrent detected on nozzle heater."
+  id: "NOZZLE_OVERCURRENT"
+  approved: true
+- code: "16309"
+  title: "HEATBED PORT OVERCURRENT"
+  text: "Overcurrent detected on xBuddy heatbed port, disconnect the device."
+  id: "INPUT_OVERCURRENT"
+  approved: true
+- code: "16310"
+  title: "MMU OVERCURRENT"
+  text: "Overcurrent detected on the MMU port, disconnect the device."
+  id: "MMU_OVERCURRENT"
+  approved: true
+- code: "16311"
+  title: "I2C SEND FAILED"
+  text: "HAL detected an I2C error when sending data via I2C."
+  id: "I2C_TX_ERROR"
+  approved: true
+- code: "16312"
+  title: "I2C SEND BUSY"
+  text: "HAL detected an I2C busy when sending data via I2C."
+  id: "I2C_TX_BUSY"
+  approved: true
+- code: "16313"
+  title: "I2C SEND TIMEOUT"
+  text: "HAL detected an I2C timeout when sending data via I2C."
+  id: "I2C_TX_TIMEOUT"
+  approved: true
+- code: "16314"
+  title: "I2C SEND UNDEFINED"
+  text: "HAL detected an I2C undefined error when sending data via I2C."
+  id: "I2C_TX_UNDEFINED"
+  approved: true
+- code: "16315"
+  title: "I2C RECEIVE FAILED"
+  text: "HAL detected an I2C error when receiving data via I2C."
+  id: "I2C_RX_ERROR"
+  approved: true
+- code: "16316"
+  title: "EEPROM I2C RECEIVE BUSY"
+  text: "HAL detected an I2C busy when receiving data via I2C."
+  id: "I2C_RX_BUSY"
+  approved: true
+- code: "16317"
+  title: "I2C RECEIVE TIMEOUT"
+  text: "HAL detected an I2C timeout when receiving data via I2C."
+  id: "I2C_RX_TIMEOUT"
+  approved: true
+- code: "16318"
+  title: "I2C RECEIVE UNDEFINED"
+  text: "HAL detected an I2C undefined error when receiving data via I2C."
+  id: "I2C_RX_UNDEFINED"
+  approved: true
+- code: "16319"
+  title: "MODULAR BED ERROR"
+  text: "Power failure"
+  id: "MB_FAULT"
+- code: "16320"
+  title: "MODULAR BED ERROR"
+  text: "Power panic"
+  id: "MB_PANIC"
+  approved: true
+- code: "16321"
+  title: "POWER PANIC"
+  text: "Power panic has been detected during printer initialization. Inspect wiring of PP-cable."
+  id: "ACF_AT_INIT"
+  approved: false
+- code: "16501"
+  title: "MODULAR BED ERROR"
+  text: "Heatbed tile no. %d:\nUnknown error: %d"
+  id: "MB_UNKNOWN_ERR"
+  approved: false
+- code: "16504"
+  title: "ESP ERROR"
+  text: "Reading ESP firmware failed."
+  id: "ESP_FW_READ"
+  approved: true
+- code: "16505"
+  title: "ESP ERROR"
+  text: "ESP detected command error."
+  id: "ESP_COMMAND_ERR"
+  approved: true
+- code: "16506"
+  title: "ESP ERROR"
+  text: "ESP detected unknown error."
+  id: "ESP_UNKNOWN_ERR"
+  approved: true
+- code: "16507"
+  title: "OUT OF MEMORY"
+  text: "Dynamic allocation failed - out of memory. Reset the printer."
+  id: "MALLOC_ERROR"
+  approved: true
+- code: "16508"
+  title: "PNG BUFFER FULL"
+  text: "Allocation of dynamic buffer for PNG failed - out of memory."
+  id: "PNG_MALLOC_ERROR"
+  approved: true
+- code: "16510"
+  title: "EMERGENCY STOP"
+  text: "Emergency stop invoked from G-code (M112)."
+  id: "EMERGENCY_STOP"
+  approved: true
+- code: "16511"
+  title: "PUPPY ERROR"
+  text: "Address assignment error"
+  id: "PUPPY_ADDR_ASSIGN_ERR"
+  approved: false
+- code: "16512"
+  title: "PUPPY ERROR"
+  text: "Unassigned puppy found"
+  id: "PUPPY_NO_ADDR"
+  approved: false
+- code: "16513"
+  title: "PUPPY ERROR"
+  text: "Puppy discovery error. No puppy found"
+  id: "PUPPY_DISCOVER_ERR"
+  approved: false
+- code: "16514"
+  title: "PUPPY ERROR"
+  text: "Puppy %s not responding"
+  id: "PUPPY_NOT_RESPONDING"
+  approved: false
+- code: "16515"
+  title: "PUPPY ERROR"
+  text: "Puppy uses incompatible bootloader protocol %04x, Buddy FW requires %04x"
+  id: "PUPPY_INCOMPATIBLE_BOOTLODER"
+  approved: false
+- code: "16516"
+  title: "PUPPY ERROR"
+  text: "Unknown puppy type"
+  id: "PUPPY_UNKNOWN_TYPE"
+  approved: false  
+- code: "16517"
+  title: "PUPPY ERROR"
+  text: "Unable to start puppy application"
+  id: "PUPPY_START_APP_ERR"
+  approved: false   
+- code: "16518"
+  title: "PUPPY ERROR"
+  text: "Puppy %s firmware not found"
+  id: "PUPPY_FW_NOT_FOUND"
+  approved: false 
+- code: "16519"
+  title: "PUPPY ERROR"
+  text: "Puppy %s flash writing failed"
+  id: "PUPPY_WRITE_FLASH_ERR"
+  approved: false 
+- code: "16520"
+  title: "PUPPY ERROR"
+  text: "Puppy %s firmware fingerprint mismatch"
+  id: "PUPPY_FINGERPRINT_MISMATCH"
+  approved: false 
+- code: "16521"
+  title: "PUPPY ERROR"
+  text: "Waiting for fingerprint timed out"
+  id: "PUPPY_FINGERPRINT_TIMEOUT"
+  approved: false 
+- code: "16522"
+  title: "PUPPY ERROR"
+  text: "Waiting for puppies to start timed out"
+  id: "PUPPY_RUN_TIMEOUT"
+  approved: false
+- code: "16523"
+  title: "LOADCELL NOT CALIBRATED"
+  text: "Loadcell calibration is incomplete. Restart the printer."
+  id: "LOADCELL_INCOMPLETE_CONFIGURATION_ERROR"
+  approved: true
+- code: "16524"
+  title: "LOADCELL TARE ERROR"
+  text: "There was an error requesting the tare for loadcell."
+  id: "LOADCELL_TARE_ALREADY_REQUESTED"
+  approved: true
+- code: "16525"
+  title: "LOADCELL TARE FAILED"
+  text: "Setting the tare failed. Check the loadcell wiring and connection."
+  id: "LOADCELL_TARE_FAILED"
+  approved: true
+- code: "16526"
+  title: "LOADCELL MEASURE FAILED"
+  text: "Loadcell measured an inifinite or undefined load value."
+  id: "LOADCELL_INFINITE_LOAD"
+  approved: true
+- code: "16527"
+  title: "LOADCELL BAD CONFIGURATION"
+  text: "The loadcell configuration is incorrect."
+  id: "LOADCELL_BAD_CONFIGURATION"
+  approved: true
+- code: "16528"
+  title: "LOADCELL TIMEOUT"
+  text: "There was a timeout while waiting for measurement sample, please repeat the action."
+  id: "LOADCELL_TIMEOUT"
+  approved: true
+- code: "16529"
+  title: "LED MEMORY ERROR"
+  text: "Memory allocation failed for scheduled LED animation"
+  id: "LED_ANIMATION_BAD_SPACE_MANAGEMENT"
+  approved: true
+- code: "16530"
+  title: "MARLIN REQUEST TIMEOUT"
+  text: "Marlin client could not send message to Marlin server and timeout was reached."
+  id: "MARLIN_CLIENT_SERVER_REQUEST_TIMEOUT"
+  approved: true
+- code: "16531"
+  title: "BBF ALLOCATION FAILED"
+  text: "Space allocation for firmware BBF file failed. Repeat the action or try another USB drive."
+  id: "BBF_ALLOCATION_FAILED"
+  approved: true
+- code: "16532"
+  title: "BBF INITIALIZATION FAILED"
+  text: "BBF initialization failed, repeat the action or try another USB drive."
+  id: "BBF_INIT_FAILED"
+  approved: true
+- code: "16533"
+  title: "ESP NOT CONNECTED"
+  text: "ESP doesn't seem to be connected."
+  id: "ESP_NOT_CONNECTED"
+- code: "16602"
+  title: ""
+  text: "USB drive not\nconnected! Please\ninsert a USB drive\nwith a valid\nfirmware file."
+  id: "USB_NOT_CONNECTED"
+  approved: true
+- code: "16603"
+  title: ""
+  text: "Firmware file has\ninvalid size!\nCheck the file\non the USB drive\nand try again."
+  id: "INVALID_FW_SIZE_ON_USB"
+  approved: true
+- code: "16604"
+  title: ""
+  text: "Firmware file\nmissing in the USB\nflash!"
+  id: "NO_FW_ON_USB"
+  approved: true
+- code: "16605"
+  title: ""
+  text: "Error erasing\n flash! Restart\nthe printer and\ntry again."
+  id: "FLASH_ERASE_ERROR"
+  approved: true
+- code: "16606"
+  title: ""
+  text: "Firmware signature\nverification failed!\nOnly official\nsigned firmware can\nbe flashed."
+  id: "SIGNATURE_VERIFICATION_FAILED"
+  approved: true
+- code: "16607"
+  title: ""
+  text: "Firmware hash\nverification failed!\nFirmware file is\ndamaged. Try\ndownloading and\ncopying it onto the\nUSB drive again."
+  id: "HASH_VERIFICATION_FAILED"
+  approved: true
+- code: "16608"
+  title: ""
+  text: "Firmware in the\ninternal flash\ncorrupted! Please\nreflash the\nfirmware."
+  id: "FW_IN_INTERNAL_FLASH_CORRUPTED"
+  approved: true
+- code: "16610"
+  title: ""
+  text: "Firmware/printer\ntypes do not match.\nMake sure you have\nthe right firmware\nfile for your\nprinter model."
+  id: "UNSUPPORTED_PRINTER_TYPE"
+  approved: true
+- code: "16611"
+  title: ""
+  text: "Firmware/printer\nversions do not\nmatch! You are\ntrying to flash\nFW meant for other\nrevision of the\nBuddy board."
+  id: "UNSUPPORTED_PRINTER_VERSION"
+  approved: true
+- code: "16612"
+  title: ""
+  text: "No firmware found\nin the internal\nflash! Please\nflash firmware\nfirst!"
+  id: "NO_FW_IN_INTERNAL_FLASH"
+  approved: true
+- code: "16613"
+  title: ""
+  text: "File system error!\nTry a different USB\ndrive or format the\ndrive with FAT32\nfilesystem (all \ndata will be lost)!"
+  id: "FILE_SYSTEM_ERROR"
+  approved: true
+- code: "16614"
+  title: ""
+  text: "USB flash drive contains\nunsupported firmware BBF file."
+  id: "UNSUPPORTED_BBF_VERSION"
+  approved: true

--- a/20_MK35/error-codes.yaml
+++ b/20_MK35/error-codes.yaml
@@ -1,0 +1,311 @@
+---
+# Error codes list for Original Prusa MK3.5 printer
+# GitHub repo https://github.com/prusa3d/Prusa-Error-Codes
+# Printer code
+# MK3.5          20xxx
+# Error categories
+# MECHANICAL     xx1xx   # Mechanical failures, engines XYZ, tower
+# TEMPERATURE    xx2xx   # Temperature measurement, thermistors, heating
+# ELECTRICAL     xx3xx   # Electrical, MINDA, FINDA, Motion Controller, …
+# CONNECTIVITY   xx4xx   # Connectivity - Wi - Fi, LAN, Prusa Connect Cloud
+# SYSTEM         xx5xx   # System - BSOD, ...
+# BOOTLOADER     xx6xx   #
+# WARNINGS       xx7xx   # Category-less warnings
+
+Errors:
+# XX103 reserved
+- code: "20201"
+  title: "PREHEAT ERROR"
+  text: "Check the heatbed heater & thermistor wiring for possible damage."
+  id: "BED_PREHEAT_ERROR"
+  approved: true
+- code: "20202"
+  title: "PREHEAT ERROR"
+  text: "Check the print head heater & thermistor wiring for possible damage."
+  id: "HOTEND_PREHEAT_ERROR"
+  approved: true
+- code: "20203"
+  title: "THERMAL RUNAWAY"
+  text: "Check the heatbed thermistor wiring for possible damage."
+  id: "BED_THERMAL_RUNAWAY"
+  approved: true
+- code: "20204"
+  title: "THERMAL RUNAWAY"
+  text: "Check the print head thermistor wiring for possible damage."
+  id: "HOTEND_THERMAL_RUNAWAY"
+  approved: true
+- code: "20205"
+  title: "MAXTEMP ERROR"
+  text: "Check the heatbed thermistor wiring for possible damage."
+  id: "BED_MAXTEMP_ERROR"
+  approved: true
+- code: "20206"
+  title: "MAXTEMP ERROR"
+  text: "Check the print head thermistor wiring for possible damage."
+  id: "HOTEND_MAXTEMP_ERROR"
+  approved: true
+- code: "20207"
+  title: "MINTEMP ERROR"
+  text: "Check the heatbed thermistor wiring for possible damage."
+  id: "BED_MINTEMP_ERROR"
+  approved: true
+- code: "20208"
+  title: "MINTEMP ERROR"
+  text: "Check the print head thermistor wiring for possible damage."
+  id: "HOTEND_MINTEMP_ERROR"
+  approved: true
+- code: "20209"
+  title: "TEMP NOT MATCHING"
+  text: "Measured temperature is not matching expected value. Check the thermistor is in contact with heatbed. In case of damage, replace it."
+  id: "BED_TEMP_NOT_MATCHING"
+  approved: true
+- code: "20210"
+  title: "TEMP NOT MATCHING"
+  text: "Measured temperature is not matching expected value. Check the thermistor is in contact with hotend. In case of damage, replace it."
+  id: "HOTEND_TEMP_NOT_MATCHING"
+  approved: true
+- code: "20211"
+  title: "HEATBREAK MINTEMP ERROR"
+  text: "Check the heatbreak thermistor wiring for possible damage."
+  id: "HEATBREAK_MINTEMP_ERR"
+  approved: true
+- code: "20212"
+  title: "HEATBREAK MAXTEMP ERROR"
+  text: "Check the heatbreak thermistor wiring for possible damage."
+  id: "HEATBREAK_MAXTEMP_ERR"
+  approved: true
+  # XX250-XX257 reserved
+- code: "20301"
+  title: "HOMING ERROR Z"
+  text: "Failed to home the extruder in Z-axis, make sure the loadcell is working."
+  id: "HOMING_ERROR_Z"
+  approved: true
+  # XX302-XX303 reserved
+- code: "20304"
+  title: "HOMING ERROR X"
+  text: "Failed to home the extruder in X-axis, make sure there is no obstacle on X-axis."
+  id: "HOMING_ERROR_X"
+  approved: true
+- code: "20305"
+  title: "HOMING ERROR Y"
+  text: "Failed to home the Y-axis, make sure there is no obstacle on Y-axis."
+  id: "HOMING_ERROR_Y"
+  approved: true
+- code: "20306"
+  title: "USB PORT OVERCURRENT"
+  text: "Overcurrent detected on USB port."
+  id: "USB_HOST_OVERCURRENT"
+  approved: true
+- code: "20307"
+  title: "USB DEVICE OVERCURRENT"
+  text: "Overcurrent detected on connected USB device, disconnect it."
+  id: "USB_DEVICE_OVERCURRENT"
+  approved: true
+- code: "20308"
+  title: "NOZZLE HEATER OVERCURRENT"
+  text: "Overcurrent detected on nozzle heater."
+  id: "NOZZLE_OVERCURRENT"
+  approved: true
+- code: "20309"
+  title: "HEATBED PORT OVERCURRENT"
+  text: "Overcurrent detected on xBuddy heatbed port, disconnect the device."
+  id: "INPUT_OVERCURRENT"
+  approved: true
+- code: "20310"
+  title: "MMU OVERCURRENT"
+  text: "Overcurrent detected on the MMU port, disconnect the device."
+  id: "MMU_OVERCURRENT"
+  approved: true
+- code: "20311"
+  title: "I2C SEND FAILED"
+  text: "HAL detected an I2C error when sending data via I2C."
+  id: "I2C_TX_ERROR"
+  approved: true
+- code: "20312"
+  title: "I2C SEND BUSY"
+  text: "HAL detected an I2C busy when sending data via I2C."
+  id: "I2C_TX_BUSY"
+  approved: true
+- code: "20313"
+  title: "I2C SEND TIMEOUT"
+  text: "HAL detected an I2C timeout when sending data via I2C."
+  id: "I2C_TX_TIMEOUT"
+  approved: true
+- code: "20314"
+  title: "I2C SEND UNDEFINED"
+  text: "HAL detected an I2C undefined error when sending data via I2C."
+  id: "I2C_TX_UNDEFINED"
+  approved: true
+- code: "20315"
+  title: "I2C RECEIVE FAILED"
+  text: "HAL detected an I2C error when receiving data via I2C."
+  id: "I2C_RX_ERROR"
+  approved: true
+- code: "20316"
+  title: "I2C RECEIVE BUSY"
+  text: "HAL detected an I2C busy when receiving data via I2C."
+  id: "I2C_RX_BUSY"
+  approved: true
+- code: "20317"
+  title: "I2C RECEIVE TIMEOUT"
+  text: "HAL detected an I2C timeout when receiving data via I2C."
+  id: "I2C_RX_TIMEOUT"
+  approved: true
+- code: "20318"
+  title: "I2C RECEIVE UNDEFINED"
+  text: "HAL detected an I2C undefined error when receiving data via I2C."
+  id: "I2C_RX_UNDEFINED"
+  approved: true
+  # XX319-XX320 reserved
+- code: "20321"
+  title: "POWER PANIC"
+  text: "Power panic has been detected during printer initialization. Inspect wiring of PP-cable."
+  id: "ACF_AT_INIT"
+  approved: false
+  # XX501-XX503 reserved
+- code: "20504"
+  title: "ESP ERROR"
+  text: "Reading ESP firmware failed."
+  id: "ESP_FW_READ"
+  approved: true
+- code: "20505"
+  title: "ESP ERROR"
+  text: "ESP detected command error."
+  id: "ESP_COMMAND_ERR"
+  approved: true
+- code: "20506"
+  title: "ESP ERROR"
+  text: "ESP detected unknown error."
+  id: "ESP_UNKNOWN_ERR"
+  approved: true
+- code: "20507"
+  title: "OUT OF MEMORY"
+  text: "Dynamic allocation failed - out of memory. Reset the printer."
+  id: "MALLOC_ERROR"
+  approved: true
+- code: "20508"
+  title: "PNG BUFFER FULL"
+  text: "Allocation of dynamic buffer for PNG failed - out of memory."
+  id: "PNG_MALLOC_ERROR"
+  approved: true
+- code: "20510"
+  title: "EMERGENCY STOP"
+  text: "Emergency stop invoked from G-code (M112)."
+  id: "EMERGENCY_STOP"
+  approved: true
+  # XX511-XX522 reserved
+- code: "20523"
+  title: "LOADCELL NOT CALIBRATED"
+  text: "Loadcell calibration is incomplete. Restart the printer."
+  id: "LOADCELL_INCOMPLETE_CONFIGURATION_ERROR"
+  approved: true
+- code: "20524"
+  title: "LOADCELL TARE ERROR"
+  text: "There was an error requesting the tare for loadcell."
+  id: "LOADCELL_TARE_ALREADY_REQUESTED"
+  approved: true
+- code: "20525"
+  title: "LOADCELL TARE FAILED"
+  text: "Setting the tare failed. Check the loadcell wiring and connection."
+  id: "LOADCELL_TARE_FAILED"
+  approved: true
+- code: "20526"
+  title: "LOADCELL MEASURE FAILED"
+  text: "Loadcell measured an inifinite or undefined load value."
+  id: "LOADCELL_INFINITE_LOAD"
+  approved: true
+- code: "20527"
+  title: "LOADCELL BAD CONFIGURATION"
+  text: "The loadcell configuration is incorrect."  
+  id: "LOADCELL_BAD_CONFIGURATION"
+  approved: true
+- code: "20528"
+  title: "LOADCELL TIMEOUT"
+  text: "There was a timeout while waiting for measurement sample, please repeat the action."
+  id: "LOADCELL_TIMEOUT"
+  approved: true
+- code: "20529"
+  title: "LED MEMORY ERROR"
+  text: "Memory allocation failed for scheduled LED animation"
+  id: "LED_ANIMATION_BAD_SPACE_MANAGEMENT"
+  approved: true
+- code: "20530"
+  title: "MARLIN REQUEST TIMEOUT"
+  text: "Marlin client could not send message to Marlin server and timeout was reached."
+  id: "MARLIN_CLIENT_SERVER_REQUEST_TIMEOUT"
+  approved: true
+- code: "20531"
+  title: "BBF ALLOCATION FAILED"
+  text: "Space allocation for firmware BBF file failed. Repeat the action or try another USB drive."
+  id: "BBF_ALLOCATION_FAILED"
+  approved: true
+- code: "20532"
+  title: "BBF INITIALIZATION FAILED"
+  text: "BBF initialization failed, repeat the action or try another USB drive."
+  id: "BBF_INIT_FAILED"
+  approved: true
+- code: "20533"
+  title: "ESP NOT CONNECTED"
+  text: "ESP doesn't seem to be connected."
+  id: "ESP_NOT_CONNECTED"
+  approved: false
+- code: "20602"
+  title: ""
+  text: "USB drive not\nconnected! Please\ninsert a USB drive\nwith a valid\nfirmware file."
+  id: "USB_NOT_CONNECTED"
+  approved: true
+- code: "20603"
+  title: ""
+  text: "Firmware file has\ninvalid size!\nCheck the file\non the USB drive\nand try again."
+  id: "INVALID_FW_SIZE_ON_USB"
+  approved: true
+- code: "20604"
+  title: ""
+  text: "Firmware file\nmissing in the USB\nflash!"
+  id: "NO_FW_ON_USB"
+  approved: true
+- code: "20605"
+  title: ""
+  text: "Error erasing\n flash! Restart\nthe printer and\ntry again."
+  id: "FLASH_ERASE_ERROR"
+  approved: true
+- code: "20606"
+  title: ""
+  text: "Firmware signature\nverification failed!\nOnly official\nsigned firmware can\nbe flashed."
+  id: "SIGNATURE_VERIFICATION_FAILED"
+  approved: true
+- code: "20607"
+  title: ""
+  text: "Firmware hash\nverification failed!\nFirmware file is\ndamaged. Try\ndownloading and\ncopying it onto the\nUSB drive again."
+  id: "HASH_VERIFICATION_FAILED"
+  approved: true
+- code: "20608"
+  title: ""
+  text: "Firmware in the\ninternal flash\ncorrupted! Please\nreflash the\nfirmware."
+  id: "FW_IN_INTERNAL_FLASH_CORRUPTED"
+  approved: true
+- code: "20610"
+  title: ""
+  text: "Firmware/printer\ntypes do not match.\nMake sure you have\nthe right firmware\nfile for your\nprinter model."
+  id: "UNSUPPORTED_PRINTER_TYPE"
+  approved: true
+- code: "20611"
+  title: ""
+  text: "Firmware/printer\nversions do not\nmatch! You are\ntrying to flash\nFW meant for other\nrevision of the\nBuddy board."
+  id: "UNSUPPORTED_PRINTER_VERSION"
+  approved: true
+- code: "20612"
+  title: ""
+  text: "No firmware found\nin the internal\nflash! Please\nflash firmware\nfirst!"
+  id: "NO_FW_IN_INTERNAL_FLASH"
+  approved: true
+- code: "20613"
+  title: ""
+  text: "File system error!\nTry a different USB\ndrive or format the\ndrive with FAT32\nfilesystem (all \ndata will be lost)!"
+  id: "FILE_SYSTEM_ERROR"
+  approved: true
+- code: "20614"
+  title: ""
+  text: "USB flash drive contains\nunsupported firmware BBF file."
+  id: "UNSUPPORTED_BBF_VERSION"
+  approved: true


### PR DESCRIPTION
This is done manually again as
git subrepo push lib/Prusa-Error-Codes
was failing with
git-subrepo: Can't commit: 'subrepo/lib/Prusa-Error-Codes' doesn't contain upstream HEAD: