### PR TITLE
Add type to MMU errors

### DIFF
--- a/04_MMU/error-codes.yaml
+++ b/04_MMU/error-codes.yaml
@@ -28,6 +28,7 @@ Errors:
   action: [Retry]
   id: "FINDA_DIDNT_TRIGGER"
   approved: true
+  type: WARNING
 
 - code: "04102"
   title: "FINDA FILAM. STUCK"
@@ -114,6 +115,7 @@ Errors:
   action: [Continue,ResetMMU]
   id: "WARNING_TMC_PULLEY_TOO_HOT"
   approved: true
+  type: ERROR
 
 - code: "04211"
   title: "WARNING TMC TOO HOT"
@@ -349,6 +351,7 @@ Errors:
   action: [Continue]
   id: "FILAMENT_EJECTED"
   approved: true
+  type: USER_ACTION
 
 - code: "04900"
   title: "UNKNOWN ERROR"


### PR DESCRIPTION
The type is meant to distinguish actual errors from warnings regular workflow dialogs.

The default `type` (if not specified) is `ERROR`, is that correct @JakoobCZ ?