### PR TITLE
Add unused but implemented errors

### DIFF
--- a/12_MINI/error-codes.yaml
+++ b/12_MINI/error-codes.yaml
@@ -215,6 +215,11 @@ Errors:
   text: "ESP doesn't seem to be connected."
   id: "ESP_NOT_CONNECTED"
   approved: false
+- code: "12601"
+  title: ""
+  text: "This error code\nis not found in\nour database.\nContact the support."
+  id: "UNKNOWN_ERROR_CODE"
+  approved: true
 - code: "12602"
   title: ""
   text: "USB drive not\nconnected! Please\ninsert a USB drive\nwith a valid\nfirmware file."
@@ -249,6 +254,11 @@ Errors:
   title: ""
   text: "Firmware in the\ninternal flash\ncorrupted! Please\nreflash the\nfirmware."
   id: "FW_IN_INTERNAL_FLASH_CORRUPTED"
+  approved: true
+- code: "12609"
+  title: ""
+  text: "Firmware and hardware\nversions do not\nmatch. Make sure\nyou have the right\nfirmware file for\nyour printer."
+  id: "HW_VERSION_ERR"
   approved: true
 - code: "12610"
   title: ""

--- a/13_MK4/error-codes.yaml
+++ b/13_MK4/error-codes.yaml
@@ -323,6 +323,12 @@ Errors:
   id: "ESP_NOT_CONNECTED"
   approved: false
   
+- code: "13601"
+  title: ""
+  text: "This error code is not found\nin our database.\nContact the support."
+  id: "UNKNOWN_ERROR_CODE"
+  approved: true
+
 - code: "13602"
   title: ""
   text: "USB drive not\nconnected! Please\ninsert a USB drive\nwith a valid\nfirmware file."
@@ -364,6 +370,12 @@ Errors:
   id: "FW_IN_INTERNAL_FLASH_CORRUPTED"
   approved: true
   
+- code: "13609"
+  title: ""
+  text: "Firmware and hardware versions do\nnot match. Make sure you have\nthe right firmware file for\nyour printer."
+  id: "HW_VERSION_ERR"
+  approved: true
+
 - code: "13610"
   title: ""
   text: "Firmware/printer\ntypes do not match.\nMake sure you have\nthe right firmware\nfile for your\nprinter model."

--- a/16_iX/error-codes.yaml
+++ b/16_iX/error-codes.yaml
@@ -384,6 +384,11 @@ Errors:
   title: "ESP NOT CONNECTED"
   text: "ESP doesn't seem to be connected."
   id: "ESP_NOT_CONNECTED"
+- code: "16601"
+  title: ""
+  text: "This error code is not found\nin our database.\nContact the support."
+  id: "UNKNOWN_ERROR_CODE"
+  approved: true
 - code: "16602"
   title: ""
   text: "USB drive not\nconnected! Please\ninsert a USB drive\nwith a valid\nfirmware file."
@@ -418,6 +423,11 @@ Errors:
   title: ""
   text: "Firmware in the\ninternal flash\ncorrupted! Please\nreflash the\nfirmware."
   id: "FW_IN_INTERNAL_FLASH_CORRUPTED"
+  approved: true
+- code: "16609"
+  title: ""
+  text: "Firmware and hardware versions do\nnot match. Make sure you have\nthe right firmware file for\nyour printer."
+  id: "HW_VERSION_ERR"
   approved: true
 - code: "16610"
   title: ""

--- a/17_XL/error-codes.yaml
+++ b/17_XL/error-codes.yaml
@@ -395,6 +395,11 @@ Errors:
   text: "ESP doesn't seem to be connected."
   id: "ESP_NOT_CONNECTED"
   approved: false
+- code: "17601"
+  title: ""
+  text: "This error code is not found\nin our database.\nContact the support."
+  id: "UNKNOWN_ERROR_CODE"
+  approved: true
 - code: "17602"
   title: "USB FLASH DRIVE NOT CONNECTED"
   text: "USB drive not connected! \nPlease insert a USB drive with a valid firmware file."
@@ -429,6 +434,11 @@ Errors:
   title: "FW IN INTERNAL FLASH CORRUPTED"
   text: "Firmware in the\ninternal flash\ncorrupted! Please\nreflash the\nfirmware."
   id: "FW_IN_INTERNAL_FLASH_CORRUPTED"
+  approved: true
+- code: "17609"
+  title: ""
+  text: "Firmware and hardware versions do\nnot match. Make sure you have\nthe right firmware file for\nyour printer."
+  id: "HW_VERSION_ERR"
   approved: true
 - code: "17610"
   title: "UNSUPPORTED PRINTER MODEL"

--- a/20_MK3.5/error-codes.yaml
+++ b/20_MK3.5/error-codes.yaml
@@ -254,6 +254,11 @@ Errors:
   text: "ESP doesn't seem to be connected."
   id: "ESP_NOT_CONNECTED"
   approved: false
+- code: "20601"
+  title: ""
+  text: "This error code is not found\nin our database.\nContact the support."
+  id: "UNKNOWN_ERROR_CODE"
+  approved: true
 - code: "20602"
   title: ""
   text: "USB drive not\nconnected! Please\ninsert a USB drive\nwith a valid\nfirmware file."
@@ -288,6 +293,11 @@ Errors:
   title: ""
   text: "Firmware in the\ninternal flash\ncorrupted! Please\nreflash the\nfirmware."
   id: "FW_IN_INTERNAL_FLASH_CORRUPTED"
+  approved: true
+- code: "20609"
+  title: ""
+  text: "Firmware and hardware versions do\nnot match. Make sure you have\nthe right firmware file for\nyour printer."
+  id: "HW_VERSION_ERR"
   approved: true
 - code: "20610"
   title: ""


### PR DESCRIPTION
General error is a error fallback in case of unrecognised error number.
HW version error is not used in bootloader (was in the past), but the implementation is prepared.