### PR TITLE
Add MCU_MAXTEMP_ERR to MK3.5

### DIFF
--- a/20_MK3.5/error-codes.yaml
+++ b/20_MK3.5/error-codes.yaml
@@ -74,6 +74,11 @@ Errors:
   text: "Check the heatbreak thermistor wiring for possible damage."
   id: "HEATBREAK_MAXTEMP_ERR"
   approved: true
+- code: "20213"
+  title: "MCU MAXTEMP ERROR"
+  text: "MCU in %s is overheated."
+  id: "MCU_MAXTEMP_ERR"
+  approved: false
   # XX250-XX257 reserved
 - code: "20301"
   title: "HOMING ERROR Z"


### PR DESCRIPTION
In the last PR, I forgot to add this error to MK3.5 as well.