### PR TITLE
Change the text of failed Z axis home on mk3.5

### DIFF
--- a/23_MK3.5/error-codes.yaml
+++ b/23_MK3.5/error-codes.yaml
@@ -74,7 +74,7 @@ Errors:
   # XX250-XX257 reserved
 - code: "23301"
   title: "HOMING ERROR Z"
-  text: "Failed to home the extruder in Z-axis, make sure the loadcell is working."
+  text: "Failed to home the extruder in Z-axis."
   id: "HOMING_ERROR_Z"
   approved: true
   # XX302-XX303 reserved


### PR DESCRIPTION
Remove the mention of loadcell on MK3.5 (It has MK3 head)