### PR TITLE
Add Connect warnings for further issues

### DIFF
--- a/yaml/buddy-error-codes.yaml
+++ b/yaml/buddy-error-codes.yaml
@@ -978,3 +978,15 @@ Errors:
     text: ""
     id: "XL_ENCLOSURE_FILTER_EXPIRATION"
     type: "CONNECT"
+  - code: "XX832"
+    printers: [iX, MK4, MK3.5, MINI, XL]
+    title: ""
+    text: ""
+    id: "PROBING_FAILED"
+    type: "CONNECT"
+  - code: "XX833"
+    printers: [iX, MK4, MK3.5, XL]
+    title: ""
+    text: ""
+    id: "NOZZLE_CLEANING_FAILED"
+    type: "CONNECT"


### PR DESCRIPTION
Part of migrating the `error` bit field in marlin server to generalized FSM handling (which allows sending them to Connect).