### PR TITLE
Remove MK3.5 inaccessible error

### DIFF
--- a/yaml/buddy-error-codes.yaml
+++ b/yaml/buddy-error-codes.yaml
@@ -1034,7 +1034,7 @@ Errors:
     id: "PROBING_FAILED"
     type: "CONNECT"
   - code: "XX834"
-    printers: [iX, MK4, MK3.5, XL]
+    printers: [iX, MK4, XL]
     title: ""
     text: "Nozzle cleaning failed."
     id: "NOZZLE_CLEANING_FAILED"


### PR DESCRIPTION
Remove `Nozzle Cleaning failed` error from mk3.5, because it doesn't have loadcell.