### PR TITLE
Add XL to printers that have "loading tube"

### DIFF
--- a/yaml/buddy-error-codes.yaml
+++ b/yaml/buddy-error-codes.yaml
@@ -1079,7 +1079,7 @@ Errors:
     type: "CONNECT"
 
   - code: "XX836"
-    printers: [iX]
+    printers: [iX, XL]
     title: "Loading Timeout"
     text: "Filament loading timed out."
     id: "FILAMENT_LOADING_TIMEOUT"


### PR DESCRIPTION
... and can therefore timeout during loading assistance