### PR TITLE
Fix typo "beet" in GCODE_CROPPED

### DIFF
--- a/yaml/buddy-error-codes.yaml
+++ b/yaml/buddy-error-codes.yaml
@@ -711,7 +711,7 @@ Errors:
 
   - code: "XX535"
     title: "Gcode Cropped"
-    text: "G-code command was too long and did not fit in the internal buffers. As a result, it might have beet not executed correctly."
+    text: "G-code command was too long and did not fit in the internal buffers. As a result, it might not be executed correctly."
     id: "GCODE_CROPPED"
     approved: false
 

--- a/yaml/buddy-error-codes.yaml
+++ b/yaml/buddy-error-codes.yaml
@@ -711,7 +711,7 @@ Errors:
 
   - code: "XX535"
     title: "Gcode Cropped"
-    text: "G-code command was too long and did not fit in the internal buffers. As a result, it might not be executed correctly."
+    text: "G-code command was too long and did not fit in the internal buffers. As a result, it may have been executed incorrectly."
     id: "GCODE_CROPPED"
     approved: false
 


### PR DESCRIPTION
The error text for GCODE_CROPPED recently popped up on my MK4S. The wording felt a little off, and this felt like a typo snuck in. 
> "As a result, it might have beet not executed correctly."
is now phrased as
> "As a result, it might not be executed correctly."