### PR TITLE
Enable FILAMENT_LOADING_TIMEOUT for all printers

### DIFF
--- a/yaml/buddy-error-codes.yaml
+++ b/yaml/buddy-error-codes.yaml
@@ -1094,7 +1094,6 @@ Errors:
     type: "CONNECT"
 
   - code: "XX836"
-    printers: [iX, XL, COREONE]
     title: "Loading Timeout"
     text: "Filament loading timed out."
     id: "FILAMENT_LOADING_TIMEOUT"


### PR DESCRIPTION
It can't actually occur, but having it enabled on all printers avoids complicated ifdefs for its usage.