### PR TITLE
Revert "Add XL to chamber temp errors"

### DIFF
--- a/yaml/buddy-error-codes.yaml
+++ b/yaml/buddy-error-codes.yaml
@@ -270,7 +270,7 @@ Errors:
     approved: false
 
   - code: "XX214"
-    printers: [XL, COREONE]
+    printers: [COREONE]
     title: "CHAMBER MAXTEMP ERROR"
     text: "Check the chamber thermistor wiring for possible damage."
     id: "CHAMBER_MAXTEMP"
@@ -278,7 +278,7 @@ Errors:
     approved: true
 
   - code: "XX215"
-    printers: [XL, COREONE]
+    printers: [COREONE]
     title: "CHAMBER MINTEMP ERROR"
     text: "Check the chamber thermistor wiring for possible damage."
     id: "CHAMBER_MINTEMP"


### PR DESCRIPTION
This reverts commit 6a6f04907ced20cb10da9923c83726ac2c028842.

If XL will be eligable for reporting mintemp / maxtemp errors, it should get a different error text.