### PR TITLE
Update mmu-error-codes.yaml - add 508 FILAMENT_CHANGE

### DIFF
--- a/yaml/mmu-error-codes.yaml
+++ b/yaml/mmu-error-codes.yaml
@@ -447,6 +447,16 @@ Errors:
   type: USER_ACTION
   gui_layout: "mmu_dialog"
 
+- code: "04508"
+  title: "FILAMENT CHANGE"
+  text: "Change filament. Eject filament then load new filament into the MMU."
+  text_short: "Eject filament and load into the MMU."
+  action: [Eject,Load]
+  id: "FILAMENT_CHANGE"
+  approved: true
+  type: USER_ACTION
+  gui_layout: "mmu_dialog"
+
 - code: "04900"
   title: "UNKNOWN ERROR"
   text: "Unexpected error occurred."


### PR DESCRIPTION
If you look at Marlin **[Marlin\src\feature\mmu3\mmu_hw\errors_list.h](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/Marlin/src/feature/mmu3/mmu_hw/errors_list.h)**, you will see `FILAMENT_CHANGE` is listed, but missing from the **mmu-error-codes.yaml**

I am not sure about the `text:` / `text_short:`, which I wrote for this **PR**, but any advice on what it should be please let me know.

Either that we add this to the file, or we remove `ERR_SYSTEM_FILAMENT_CHANGE` and all traces from the **error_list.h** file in Marlin repo