### PR TITLE
 Change toolchanger errors

### DIFF
--- a/yaml/buddy-error-codes.yaml
+++ b/yaml/buddy-error-codes.yaml
@@ -31,13 +31,6 @@ Errors:
     gui_layout: "warning_dialog"
     approved: true
 
-  - code: "XX101"
-    printers: [XL, COREONE_INDX, COREONEL_INDX]
-    title: "TOOLCHANGER ERROR"
-    text: "Check all tools if they are properly parked or picked."
-    id: "TOOLCHANGER"
-    approved: true
-
   - code: "XX102"
     printers: [iX, COREONE, COREONE_INDX, COREONEL, COREONEL_INDX]
     title: "PRECISE HOMING FAILED"
@@ -243,6 +236,21 @@ Errors:
     text: "Please run homing calibration from the Calibrations menu. Continuing can result in homing shifts and toolcrashes."
     id: "HOMING_CALIBRATION_FROM_MENU_NEEDED"
     gui_layout: "warning_dialog"
+    approved: true
+
+  - code: "XX121"
+    printers: [XL, COREONE_INDX, COREONEL_INDX]
+    title: "TOOLCHANGER ERROR"
+    text: "Check all tools if they are properly parked or picked."
+    id: "TOOLCHANGER"
+    approved: true
+
+  - code: "XX122"
+    printers: [XL]
+    title: "CALIBRATE DOCK FROM MENU"
+    text: "Please run Dock Position Calibration from the Calibrations menu. Continuing can result in homing shifts and toolcrashes."
+    id: "DOCK_CALIBRATION_FROM_MENU_NEEDED"
+    gui_layout: "red_screen"
     approved: true
 
   # TEMPERATURE    xx2xx


### PR DESCRIPTION
- [x] to be confirmed by Product BFW-8208

Toolchanger errors move to different number, the page prusa.io/17101 is dedicated to Object manipulation panel
Dedicated error for missing dock calibration

BFW-8136